### PR TITLE
fix: use relative API URL and fix SPA routing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import ORJSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 import uvicorn
@@ -10,45 +10,32 @@ from .routers import genes, variants, literature
 
 logging.basicConfig(level=logging.INFO)
 
-api_app = FastAPI(
+app = FastAPI(
     title="RNUdb API",
     description="Simple read-only API for RNAdb data",
     default_response_class=ORJSONResponse,
 )
 
-api_app.add_middleware(
+app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "http://localhost:5173",
-        "http://localhost:8000",
-    ],
-    allow_credentials=True,
+    allow_origins=["*"],
     allow_methods=["GET"],
     allow_headers=["*"],
 )
 
+app.include_router(genes.router, prefix="/api")
+app.include_router(variants.router, prefix="/api")
+app.include_router(literature.router, prefix="/api")
 
-@api_app.get("/")
-async def root():
-    return {"message": "RNUdb API - Simple read-only access to RNA database"}
-
-
-api_app.include_router(genes.router)
-api_app.include_router(variants.router)
-api_app.include_router(literature.router)
-
-# Create a root app that serves static files at / and mounts the API under /api
-app = FastAPI(title="RNUdb (static + API gateway)")
-
-# Mount the API app under /api first so it is not shadowed by the root static mount
-app.mount("/api", api_app, name="api")
-
-# Mount static files for frontend at / (only if dist exists - for production)
+# Serve frontend static files
 dist_path = Path(__file__).resolve().parent.parent / "dist"
 if dist_path.exists():
-    app.mount("/", StaticFiles(directory=str(dist_path), html=True), name="static")
+    app.mount("/assets", StaticFiles(directory=str(dist_path / "assets")), name="assets")
+
+    # SPA fallback - serve index.html for all unmatched routes
+    @app.get("/{full_path:path}")
+    async def spa_fallback(full_path: str):
+        return FileResponse(str(dist_path / "index.html"))
 
 if __name__ == "__main__":
-    # Run the gateway app which serves the frontend and proxies API under /api
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,7 @@
 import type { SnRNAGene, Variant, Literature, LiteratureCounts, RNAStructure, PDBStructure } from '../types';
 
 // Default API base URL (hardcoded to localhost backend mounted at /api)
-const API_BASE_URL = 'http://localhost:8000/api';
+const API_BASE_URL = '/api';
 
 class ApiService {
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
 })


### PR DESCRIPTION
- Change API base URL from hardcoded `http://localhost:8000/api` to relative `/api` so it works over HTTPS
- Simplify backend: single FastAPI app instead of nested apps
- Add SPA fallback so frontend routes like `/gene/RNU4-2` don't 404
- Allow all CORS origins (public read-only API)