### PR TITLE
Add RNA structure import format documentation

### DIFF
--- a/docs/rna-structure/CHANGELOG.md
+++ b/docs/rna-structure/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to the RNA structure import format are documented here.
+
+## [1.0.0] - 2026-05-06
+
+### Added
+
+- Initial documentation of the RNA structure import format
+- Field reference for all object types (nucleotides, base_pairs, annotations, structural_features)
+- Validation rules (errors and warnings)
+- Naming convention documentation (camelCase to snake_case conversion)
+- Sample JSON files:
+  - `minimal.json` - Minimal valid structure
+  - `with-base-pairs.json` - Structure with base pair connections
+  - `with-annotations.json` - Structure with text annotations
+  - `full.json` - Complete structure with all features
+- Related links to API endpoints and components
+
+---
+
+## Versioning
+
+This document follows [Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH):
+
+- **MAJOR** - Incompatible changes to the format
+- **MINOR** - Backwards-compatible new fields or features
+- **PATCH** - Documentation updates without format changes
+
+---
+
+## Format Specification Version
+
+The current format specification version is **1.0.0**. This version is stored in the `README.md` header and should be updated whenever changes are made.
+
+---
+
+## Updating This Document
+
+When making changes to the import format:
+
+1. Update the version in `README.md` header
+2. Add an entry to this `CHANGELOG.md`
+3. If adding new fields, update the Field Reference section
+4. If adding new validation rules, update the Validation Rules section
+5. Create an issue on GitHub to track the change
+
+---
+
+## Related Issues
+
+- Issue #38: Document RNA structure import format

--- a/docs/rna-structure/README.md
+++ b/docs/rna-structure/README.md
@@ -1,0 +1,228 @@
+# RNA Structure Import Format
+
+**Version:** 1.0.0
+**Last Updated:** 2026-05-06
+**Status:** Active
+
+---
+
+## Overview
+
+This document describes the JSON file format for importing RNA secondary structures into RNUdb via the Structure Import Wizard. The format is designed to be compatible with exports from the RNA Editor.
+
+---
+
+## Quick Example
+
+```json
+{
+  "id": "rnu4-2-v1",
+  "name": "RNU4-2 Secondary Structure",
+  "nucleotides": [
+    { "id": 1, "base": "G", "x": 100, "y": 50 },
+    { "id": 2, "base": "U", "x": 110, "y": 60 }
+  ],
+  "base_pairs": [{ "from_pos": 1, "to_pos": 10 }]
+}
+```
+
+---
+
+## Field Reference
+
+### Top-Level Fields
+
+| Field                 | Type   | Required | Description                         |
+| --------------------- | ------ | -------- | ----------------------------------- |
+| `id`                  | string | Yes      | Unique identifier for the structure |
+| `name`                | string | Yes      | Human-readable name                 |
+| `nucleotides`         | array  | Yes      | Array of nucleotide objects (min 1) |
+| `base_pairs`          | array  | No       | Array of base pair connections      |
+| `annotations`         | array  | No       | Array of text annotation objects    |
+| `structural_features` | array  | No       | Array of structural feature objects |
+
+---
+
+### Nucleotide Object
+
+| Field  | Type    | Required | Description                                       |
+| ------ | ------- | -------- | ------------------------------------------------- |
+| `id`   | integer | Yes      | Unique position identifier (positive integer)     |
+| `base` | string  | Yes      | Nucleotide base: A, C, G, or U (case-insensitive) |
+| `x`    | number  | Yes      | X coordinate for visualization                    |
+| `y`    | number  | Yes      | Y coordinate for visualization                    |
+
+**Example:**
+
+```json
+{ "id": 1, "base": "G", "x": 100.0, "y": 50.0 }
+```
+
+---
+
+### Base Pair Object
+
+| Field      | Type    | Required | Description                                             |
+| ---------- | ------- | -------- | ------------------------------------------------------- |
+| `from_pos` | integer | Yes      | Starting nucleotide position (references nucleotide id) |
+| `to_pos`   | integer | Yes      | Ending nucleotide position (references nucleotide id)   |
+
+**Example:**
+
+```json
+{ "from_pos": 1, "to_pos": 10 }
+```
+
+---
+
+### Annotation Object
+
+| Field       | Type    | Required | Description                                |
+| ----------- | ------- | -------- | ------------------------------------------ |
+| `id`        | string  | Yes      | Unique annotation ID                       |
+| `text`      | string  | Yes      | Annotation text content                    |
+| `x`         | number  | Yes      | X position for the annotation              |
+| `y`         | number  | Yes      | Y position for the annotation              |
+| `font_size` | integer | Yes      | Font size in pixels                        |
+| `color`     | string  | No       | Text color as hex string (e.g., "#000000") |
+
+**Example:**
+
+```json
+{
+  "id": "ann-1",
+  "text": "5' End",
+  "x": 95,
+  "y": 45,
+  "font_size": 12,
+  "color": "#000000"
+}
+```
+
+---
+
+### Structural Feature Object
+
+| Field             | Type    | Required | Description                                                |
+| ----------------- | ------- | -------- | ---------------------------------------------------------- |
+| `id`              | string  | Yes      | Unique feature ID                                          |
+| `feature_type`    | string  | Yes      | Type of feature (e.g., "stem", "loop", "bulge", "hairpin") |
+| `nucleotide_ids`  | array   | Yes      | Array of nucleotide position IDs included in this feature  |
+| `label_text`      | string  | Yes      | Text label for the feature                                 |
+| `label_x`         | number  | Yes      | X position for the label                                   |
+| `label_y`         | number  | Yes      | Y position for the label                                   |
+| `label_font_size` | integer | Yes      | Font size for the label                                    |
+| `label_color`     | string  | No       | Label text color (hex)                                     |
+| `description`     | string  | No       | Descriptive text for the feature                           |
+| `color`           | string  | No       | Visual color for the feature (hex)                         |
+
+**Example:**
+
+```json
+{
+  "id": "feat-1",
+  "feature_type": "stem",
+  "nucleotide_ids": [1, 2, 3, 4],
+  "label_text": "Stem 1",
+  "label_x": 115,
+  "label_y": 55,
+  "label_font_size": 11,
+  "label_color": "#008000",
+  "description": "Primary stem structure",
+  "color": "#00FF00"
+}
+```
+
+---
+
+## Naming Convention
+
+The import supports both **camelCase** and **snake_case** field names. The API automatically converts camelCase to snake_case during import.
+
+| camelCase (Input)    | snake_case (Internal) |
+| -------------------- | --------------------- |
+| `basePairs`          | `base_pairs`          |
+| `structuralFeatures` | `structural_features` |
+| `fromPos`            | `from_pos`            |
+| `toPos`              | `to_pos`              |
+| `chromStart`         | `chrom_start`         |
+
+**Example (camelCase input):**
+
+```json
+{
+  "id": "example",
+  "name": "Test",
+  "nucleotides": [...],
+  "basePairs": [...],
+  "structuralFeatures": [...]
+}
+```
+
+Both formats are valid and will be processed identically.
+
+---
+
+## Validation Rules
+
+### Errors (Import Blocked)
+
+The import will fail and show errors if any of these conditions are met:
+
+| Condition                   | Error Message                                  |
+| --------------------------- | ---------------------------------------------- |
+| Missing `id`                | "Structure ID is required"                     |
+| Missing `name`              | "Structure name is required"                   |
+| Missing `nucleotides`       | "nucleotides must be an array"                 |
+| Empty `nucleotides`         | "At least one nucleotide is required"          |
+| Invalid nucleotide base     | "Invalid base 'X'. Must be A, C, G, or U"      |
+| Non-integer nucleotide ID   | "Nucleotide ID must be an integer"             |
+| Non-numeric coordinate      | "Nucleotide coordinate must be a number"       |
+| Invalid base pair reference | "Base pair references non-existent nucleotide" |
+
+### Warnings (Import Allowed)
+
+These conditions will generate warnings but will not block the import:
+
+| Condition                  | Warning Message                       |
+| -------------------------- | ------------------------------------- |
+| No base pairs defined      | "No base pairs defined"               |
+| No annotations             | "No annotations included"             |
+| No structural features     | "No structural features included"     |
+| Base pair to same position | "Base pair connects to same position" |
+
+---
+
+## Examples
+
+See the `examples/` directory for sample JSON files:
+
+| File                    | Description                                   |
+| ----------------------- | --------------------------------------------- |
+| `minimal.json`          | Minimal valid structure with just nucleotides |
+| `with-base-pairs.json`  | Structure with base pair connections          |
+| `with-annotations.json` | Structure with text annotations               |
+| `full.json`             | Complete structure with all features          |
+
+---
+
+## Related
+
+- **UI Component:** StructureImportWizard (`src/components/Curate/StructureImportWizard.tsx`)
+- **API Endpoint:** `/api/imports/structures` and `/api/imports/structures/validate`
+- **Validation Service:** `api/services/validation.py` - `validate_structure()` function
+- **Database Models:** `api/models.py` - RNAStructure, Nucleotide, BasePair, Annotation, StructuralFeature
+
+---
+
+## Version History
+
+| Version | Date       | Changes               |
+| ------- | ---------- | --------------------- |
+| 1.0.0   | 2026-05-06 | Initial documentation |
+
+---
+
+## Feedback
+
+If you encounter issues with the import format or find inconsistencies, please [report them on GitHub](https://github.com/Computational-Rare-Disease-Genomics-WHG/RNUdb/issues).

--- a/docs/rna-structure/examples/full.json
+++ b/docs/rna-structure/examples/full.json
@@ -1,0 +1,78 @@
+{
+  "id": "example-full",
+  "name": "Complete Structure Example",
+  "nucleotides": [
+    { "id": 1, "base": "G", "x": 100, "y": 50 },
+    { "id": 2, "base": "U", "x": 110, "y": 60 },
+    { "id": 3, "base": "C", "x": 120, "y": 70 },
+    { "id": 4, "base": "G", "x": 130, "y": 80 },
+    { "id": 5, "base": "A", "x": 140, "y": 90 },
+    { "id": 6, "base": "U", "x": 150, "y": 100 },
+    { "id": 7, "base": "C", "x": 160, "y": 110 },
+    { "id": 8, "base": "G", "x": 170, "y": 120 },
+    { "id": 9, "base": "A", "x": 180, "y": 130 },
+    { "id": 10, "base": "U", "x": 190, "y": 140 }
+  ],
+  "base_pairs": [
+    { "from_pos": 1, "to_pos": 10 },
+    { "from_pos": 2, "to_pos": 9 },
+    { "from_pos": 3, "to_pos": 8 },
+    { "from_pos": 4, "to_pos": 7 }
+  ],
+  "annotations": [
+    {
+      "id": "ann-1",
+      "text": "5' End",
+      "x": 95,
+      "y": 45,
+      "font_size": 12,
+      "color": "#000000"
+    },
+    {
+      "id": "ann-2",
+      "text": "3' End",
+      "x": 195,
+      "y": 145,
+      "font_size": 12,
+      "color": "#000000"
+    }
+  ],
+  "structural_features": [
+    {
+      "id": "feat-1",
+      "feature_type": "stem",
+      "nucleotide_ids": [1, 2, 3, 4],
+      "label_text": "Stem 1",
+      "label_x": 115,
+      "label_y": 55,
+      "label_font_size": 11,
+      "label_color": "#008000",
+      "description": "Primary stem region",
+      "color": "#00FF00"
+    },
+    {
+      "id": "feat-2",
+      "feature_type": "loop",
+      "nucleotide_ids": [5, 6],
+      "label_text": "Loop",
+      "label_x": 145,
+      "label_y": 95,
+      "label_font_size": 10,
+      "label_color": "#FF6600",
+      "description": "Terminal loop",
+      "color": "#FF9900"
+    },
+    {
+      "id": "feat-3",
+      "feature_type": "stem",
+      "nucleotide_ids": [7, 8, 9, 10],
+      "label_text": "Stem 2",
+      "label_x": 165,
+      "label_y": 125,
+      "label_font_size": 11,
+      "label_color": "#008000",
+      "description": "Secondary stem region",
+      "color": "#00FF00"
+    }
+  ]
+}

--- a/docs/rna-structure/examples/minimal.json
+++ b/docs/rna-structure/examples/minimal.json
@@ -1,0 +1,12 @@
+{
+  "id": "example-minimal",
+  "name": "Minimal Structure",
+  "nucleotides": [
+    { "id": 1, "base": "G", "x": 100, "y": 50 },
+    { "id": 2, "base": "U", "x": 110, "y": 60 },
+    { "id": 3, "base": "C", "x": 120, "y": 70 }
+  ],
+  "base_pairs": [],
+  "annotations": [],
+  "structural_features": []
+}

--- a/docs/rna-structure/examples/with-annotations.json
+++ b/docs/rna-structure/examples/with-annotations.json
@@ -1,0 +1,36 @@
+{
+  "id": "example-annotated",
+  "name": "Structure with Annotations",
+  "nucleotides": [
+    { "id": 1, "base": "G", "x": 100, "y": 50 },
+    { "id": 2, "base": "U", "x": 110, "y": 60 },
+    { "id": 3, "base": "C", "x": 120, "y": 70 },
+    { "id": 4, "base": "G", "x": 130, "y": 80 }
+  ],
+  "annotations": [
+    {
+      "id": "ann-1",
+      "text": "5' End",
+      "x": 95,
+      "y": 45,
+      "font_size": 12,
+      "color": "#000000"
+    },
+    {
+      "id": "ann-2",
+      "text": "3' End",
+      "x": 135,
+      "y": 85,
+      "font_size": 12,
+      "color": "#000000"
+    },
+    {
+      "id": "ann-3",
+      "text": "Conserved region",
+      "x": 115,
+      "y": 40,
+      "font_size": 10,
+      "color": "#666666"
+    }
+  ]
+}

--- a/docs/rna-structure/examples/with-base-pairs.json
+++ b/docs/rna-structure/examples/with-base-pairs.json
@@ -1,0 +1,19 @@
+{
+  "id": "example-with-pairs",
+  "name": "Structure with Base Pairs",
+  "nucleotides": [
+    { "id": 1, "base": "G", "x": 100, "y": 50 },
+    { "id": 2, "base": "U", "x": 110, "y": 60 },
+    { "id": 3, "base": "C", "x": 120, "y": 70 },
+    { "id": 4, "base": "G", "x": 130, "y": 80 },
+    { "id": 5, "base": "A", "x": 140, "y": 90 },
+    { "id": 6, "base": "U", "x": 150, "y": 100 },
+    { "id": 7, "base": "C", "x": 160, "y": 110 },
+    { "id": 8, "base": "G", "x": 170, "y": 120 }
+  ],
+  "base_pairs": [
+    { "from_pos": 1, "to_pos": 8 },
+    { "from_pos": 2, "to_pos": 7 },
+    { "from_pos": 3, "to_pos": 6 }
+  ]
+}


### PR DESCRIPTION
## Summary

Creates comprehensive documentation for the RNA structure JSON import format used by the Structure Import Wizard.

## Changes

- Created  with full documentation:
  - Overview and quick example
  - Field reference for all object types (nucleotides, base_pairs, annotations, structural_features)
  - Naming convention (camelCase to snake_case conversion)
  - Validation rules (errors and warnings)
  - Related links to API and components
- Added sample JSON files in :
  -  - Minimal valid structure
  -  - Structure with base pair connections
  -  - Structure with text annotations
  -  - Complete structure with all features
- Created  for version tracking

## Documentation Details

- **Version:** 1.0.0
- **Last Updated:** 2026-05-06
- Documents validation rules from 
- Includes examples for all object types

## Related

- Issue #38: Document RNA structure import format