### PR TITLE
Improve Data Overlay panel in RNA 2D Viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import { useAuth } from "./context/AuthContext";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import APIDocs from "./pages/APIDocs";
 import Admin from "./pages/Admin";
 import ClinicalInterpretation from "./pages/ClinicalInterpretation";
@@ -30,22 +31,24 @@ function ProtectedEditor() {
 function App() {
   return (
     <AuthProvider>
-      <Router>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/gene/:geneId" element={<Gene />} />
-          <Route path="/editor" element={<ProtectedEditor />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/admin" element={<Admin />} />
-          <Route path="/curate" element={<Curate />} />
-          <Route path="/api-docs" element={<APIDocs />} />
-          <Route
-            path="/clinical-interpretation"
-            element={<ClinicalInterpretation />}
-          />
-          <Route path="/how-to-use" element={<HowToUse />} />
-        </Routes>
-      </Router>
+      <TooltipProvider>
+        <Router>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/gene/:geneId" element={<Gene />} />
+            <Route path="/editor" element={<ProtectedEditor />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/admin" element={<Admin />} />
+            <Route path="/curate" element={<Curate />} />
+            <Route path="/api-docs" element={<APIDocs />} />
+            <Route
+              path="/clinical-interpretation"
+              element={<ClinicalInterpretation />}
+            />
+            <Route path="/how-to-use" element={<HowToUse />} />
+          </Routes>
+        </Router>
+      </TooltipProvider>
     </AuthProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import {
 } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import { useAuth } from "./context/AuthContext";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import APIDocs from "./pages/APIDocs";
 import Admin from "./pages/Admin";
 import ClinicalInterpretation from "./pages/ClinicalInterpretation";
@@ -16,6 +15,7 @@ import Gene from "./pages/Gene";
 import Home from "./pages/Home";
 import HowToUse from "./pages/HowToUse";
 import Login from "./pages/Login";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 function ProtectedEditor() {
   const { isCurator, isLoading } = useAuth();

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -31,15 +31,10 @@ interface MainContentProps {
   variantData: Variant[];
   gnomadVariants: Variant[];
   aouVariants: Variant[];
-  overlayMode:
-    | "none"
-    | "clinvar"
-    | "gnomad"
-    | "function_score"
-    | "depletion_group";
+  overlayMode: "none" | "clinvar" | "gnomad" | "depletion_group";
   getCurrentOverlayData: () => OverlayData;
   cycleOverlayMode: () => void;
-  functionScoreTrackData: OverlayData;
+  functionScoreTrackData?: OverlayData;
   depletionGroupTrackData: OverlayData;
   caddScoreTrackData: OverlayData;
 }

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -5,14 +5,16 @@ import {
   RotateCcw,
   Download,
   FileImage,
-  Database,
-  BarChart3,
+  Layers,
+  Ban,
+  AlertTriangle,
+  Activity,
+  Users,
 } from "lucide-react";
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import {
   COLORBLIND_FRIENDLY_PALETTE,
   generateGnomadColorWithAlpha,
-  getFunctionScoreColor,
 } from "../../lib/colors";
 import { findNucleotideById } from "../../lib/rnaUtils";
 import type { RNAData, Nucleotide, OverlayData, Variant } from "../../types";
@@ -29,7 +31,6 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import "./RNAViewer.css";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   getDistinctDiseaseTypes,
   getDistinctClinicalSignificances,
@@ -41,12 +42,7 @@ interface RNAViewerProps {
   overlayData?: OverlayData;
   onNucleotideClick?: (nucleotide: Nucleotide) => void;
   onNucleotideHover?: (nucleotide: Nucleotide | null) => void;
-  overlayMode?:
-    | "none"
-    | "clinvar"
-    | "gnomad"
-    | "function_score"
-    | "depletion_group";
+  overlayMode?: "none" | "clinvar" | "gnomad" | "depletion_group";
   onCycleOverlay?: () => void;
   variantData?: Variant[];
   gnomadVariants?: Variant[];
@@ -63,13 +59,18 @@ interface RNAViewerProps {
   };
 }
 
+const cyclesFromMode = (mode: string): number => {
+  const modes = ["none", "clinvar", "gnomad", "depletion_group"];
+  return modes.indexOf(mode);
+};
+
 const RNAViewer: React.FC<RNAViewerProps> = ({
   rnaData,
   pdbData,
   overlayData = {},
   onNucleotideClick,
   onNucleotideHover,
-  overlayMode = "none",
+  overlayMode = "clinvar",
   onCycleOverlay,
   variantData = [],
   gnomadVariants = [],
@@ -98,6 +99,10 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
   const [selectedClinicalSig, setSelectedClinicalSig] = useState<string>("all");
   const [selectedPopulationSource, setSelectedPopulationSource] =
     useState<string>("all");
+
+  // Clinical Variants filters
+  const [clinvarGroupBy, setClinvarGroupBy] = useState<string>("all");
+  const [selectedZygosity, setSelectedZygosity] = useState<string>("all");
 
   useEffect(() => {
     const fetchFilterOptions = async () => {
@@ -143,17 +148,35 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
 
           if (!variant.clinical_significance) return false;
 
-          if (
-            selectedDiseaseType !== "all" &&
-            variant.disease_type !== selectedDiseaseType
-          )
-            return false;
+          // Filter based on Group by selection
+          if (clinvarGroupBy === "significance") {
+            if (
+              selectedClinicalSig !== "all" &&
+              variant.clinical_significance !== selectedClinicalSig
+            )
+              return false;
+          } else if (clinvarGroupBy === "disease") {
+            if (
+              selectedDiseaseType !== "all" &&
+              variant.disease_type !== selectedDiseaseType
+            )
+              return false;
+          }
 
-          if (
-            selectedClinicalSig !== "all" &&
-            variant.clinical_significance !== selectedClinicalSig
-          )
-            return false;
+          // Filter by zygosity
+          if (selectedZygosity !== "all") {
+            if (selectedZygosity === "het") {
+              if (variant.zygosity !== "het") return false;
+            } else if (selectedZygosity === "hom") {
+              if (variant.zygosity !== "hom") return false;
+            } else if (selectedZygosity === "biallelic") {
+              const isBiallelic =
+                variant.zygosity === "hom" ||
+                (variant.linkedVariantIds &&
+                  variant.linkedVariantIds.length > 0);
+              if (!isBiallelic) return false;
+            }
+          }
 
           return true;
         });
@@ -234,15 +257,30 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
         };
       }
 
+      if (overlayMode === "depletion_group") {
+        const overlayValue = overlayData[nucleotideId];
+        if (overlayValue) {
+          const val =
+            typeof overlayValue === "number"
+              ? overlayValue
+              : overlayValue.value;
+          return { value: val || 0 };
+        }
+        return { value: 0 };
+      }
+
       return { value: 0 };
     },
     [
       overlayMode,
       variantData,
+      overlayData,
       geneData,
       selectedDiseaseType,
       selectedClinicalSig,
       selectedPopulationSource,
+      clinvarGroupBy,
+      selectedZygosity,
     ],
   );
 
@@ -314,8 +352,6 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
       return COLORBLIND_FRIENDLY_PALETTE.NEUTRAL.BACKGROUND;
     } else if (overlayMode === "gnomad") {
       return generateGnomadColorWithAlpha(value);
-    } else if (overlayMode === "function_score") {
-      return getFunctionScoreColor(value);
     } else if (overlayMode === "depletion_group") {
       if (value === 3) return COLORBLIND_FRIENDLY_PALETTE.DEPLETION.STRONG;
       if (value === 2) return COLORBLIND_FRIENDLY_PALETTE.DEPLETION.MODERATE;
@@ -465,141 +501,254 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
           </>
         )}
 
-        {/* Shared Overlay Controls */}
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2">
-            <Database className="h-4 w-4 text-slate-500" />
-            <span className="text-sm text-slate-700 font-medium">
-              Data Overlay
-            </span>
-          </div>
-          {onCycleOverlay && (
-            <ToggleGroup
-              type="single"
-              value={overlayMode}
-              onValueChange={(value) => {
-                if (value && value !== overlayMode) {
-                  const modes = [
-                    "none",
-                    "clinvar",
-                    "gnomad",
-                    "function_score",
-                    "depletion_group",
-                  ];
-                  const currentIndex = modes.indexOf(overlayMode);
-                  const targetIndex = modes.indexOf(value);
-                  const cycles =
-                    targetIndex > currentIndex
-                      ? targetIndex - currentIndex
-                      : modes.length - currentIndex + targetIndex;
+        {/* Data Overlay Panel */}
+        {onCycleOverlay && (
+          <div className="bg-white rounded-lg border border-slate-200 p-3">
+            {/* Header row with title and mode buttons */}
+            <div className="flex items-center gap-4 mb-2 min-w-0">
+              <div className="flex items-center gap-2 shrink-0">
+                <Layers className="h-4 w-4 text-teal-600" />
+                <span className="text-sm font-semibold text-slate-700 whitespace-nowrap">
+                  Data Overlay
+                </span>
+              </div>
 
-                  for (let i = 0; i < cycles; i++) {
-                    onCycleOverlay();
-                  }
-                }
-              }}
-              className="flex gap-1"
-            >
-              <ToggleGroupItem
-                value="none"
-                className="h-9 px-3 text-xs font-medium rounded-md border border-slate-200 hover:bg-slate-50 data-[state=on]:bg-slate-100 data-[state=on]:border-slate-300"
-              >
-                None
-              </ToggleGroupItem>
-              <ToggleGroupItem
-                value="clinvar"
-                className="h-9 px-3 text-xs font-medium rounded-md border border-slate-200 hover:bg-slate-50 data-[state=on]:bg-blue-50 data-[state=on]:border-blue-200 data-[state=on]:text-blue-700"
-              >
-                <div className="flex items-center gap-1.5">
-                  <div className="w-2 h-2 rounded-full bg-red-500"></div>
-                  <span>Clinical Variants</span>
-                </div>
-              </ToggleGroupItem>
-              {overlayMode === "clinvar" && diseaseTypes.length > 0 && (
-                <>
-                  <Select
-                    value={selectedDiseaseType}
-                    onValueChange={setSelectedDiseaseType}
-                  >
-                    <SelectTrigger className="h-8 w-[140px] text-xs border-slate-200">
-                      <SelectValue placeholder="Disease Type" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All Diseases</SelectItem>
-                      {diseaseTypes.map((disease) => (
-                        <SelectItem key={disease} value={disease}>
-                          {disease}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Select
-                    value={selectedClinicalSig}
-                    onValueChange={setSelectedClinicalSig}
-                  >
-                    <SelectTrigger className="h-8 w-[120px] text-xs border-slate-200">
-                      <SelectValue placeholder="Significance" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All</SelectItem>
-                      {clinicalSignificances.map((sig) => (
-                        <SelectItem key={sig} value={sig}>
-                          {sig}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </>
-              )}
-              <ToggleGroupItem
-                value="gnomad"
-                className="h-9 px-3 text-xs font-medium rounded-md border border-slate-200 hover:bg-slate-50 data-[state=on]:bg-indigo-50 data-[state=on]:border-indigo-200 data-[state=on]:text-indigo-700"
-              >
-                <div className="flex items-center gap-1.5">
-                  <div className="w-2 h-2 rounded-full bg-blue-500"></div>
-                  <span>Population Variants</span>
-                </div>
-              </ToggleGroupItem>
-              {overlayMode === "gnomad" && (
-                <Select
-                  value={selectedPopulationSource}
-                  onValueChange={setSelectedPopulationSource}
+              {/* Mode toggle buttons - fixed width container */}
+              <div className="flex items-center gap-1 shrink-0">
+                <button
+                  onClick={() => {
+                    if (overlayMode !== "none") {
+                      const cycles =
+                        [
+                          "none",
+                          "clinvar",
+                          "gnomad",
+                          "depletion_group",
+                        ].indexOf("none") - cyclesFromMode(overlayMode);
+                      for (let i = 0; i < Math.abs(cycles || 1); i++)
+                        onCycleOverlay();
+                    }
+                  }}
+                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
+                    overlayMode === "none"
+                      ? "bg-slate-200 text-slate-800"
+                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
+                  }`}
+                  title="Disable data overlay"
                 >
-                  <SelectTrigger className="h-8 w-[140px] text-xs border-slate-200">
-                    <SelectValue placeholder="Source" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Sources</SelectItem>
-                    <SelectItem value="gnomad">gnomAD v4.1</SelectItem>
-                    <SelectItem value="aou">All of Us</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-              <ToggleGroupItem
-                value="function_score"
-                className="h-9 px-3 text-xs font-medium rounded-md border border-slate-200 hover:bg-slate-50 data-[state=on]:bg-emerald-50 data-[state=on]:border-emerald-200 data-[state=on]:text-emerald-700"
-              >
-                <div className="flex items-center gap-1.5">
-                  <BarChart3 className="h-3 w-3" />
-                  SGE Function Score
+                  <Ban className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">None</span>
+                </button>
+                <button
+                  onClick={() => {
+                    const targetIndex = [
+                      "none",
+                      "clinvar",
+                      "gnomad",
+                      "depletion_group",
+                    ].indexOf("clinvar");
+                    const current = cyclesFromMode(overlayMode);
+                    for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
+                      onCycleOverlay();
+                  }}
+                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
+                    overlayMode === "clinvar"
+                      ? "bg-red-100 text-red-700"
+                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
+                  }`}
+                  title="Show ClinVar clinical variants with pathogenicity classifications"
+                >
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">Clinical Variants</span>
+                </button>
+                <button
+                  onClick={() => {
+                    const targetIndex = [
+                      "none",
+                      "clinvar",
+                      "gnomad",
+                      "depletion_group",
+                    ].indexOf("gnomad");
+                    const current = cyclesFromMode(overlayMode);
+                    for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
+                      onCycleOverlay();
+                  }}
+                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
+                    overlayMode === "gnomad"
+                      ? "bg-blue-100 text-blue-700"
+                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
+                  }`}
+                  title="Show population frequency data from gnomAD and All of Us"
+                >
+                  <Users className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">Population Variants</span>
+                </button>
+                <button
+                  onClick={() => {
+                    const targetIndex = [
+                      "none",
+                      "clinvar",
+                      "gnomad",
+                      "depletion_group",
+                    ].indexOf("depletion_group");
+                    const current = cyclesFromMode(overlayMode);
+                    for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
+                      onCycleOverlay();
+                  }}
+                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
+                    overlayMode === "depletion_group"
+                      ? "bg-orange-100 text-orange-700"
+                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
+                  }`}
+                  title="Show depletion group categories: Strong, Moderate, Normal"
+                >
+                  <Activity className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">Depletion</span>
+                </button>
+              </div>
+            </div>
+
+            {/* Current mode label and filters */}
+            {overlayMode !== "none" && (
+              <div className="flex items-center gap-2 pt-2 border-t border-slate-100 min-w-0">
+                <span className="text-xs font-medium text-slate-500 shrink-0">
+                  Filter:
+                </span>
+                <div className="flex items-center gap-2 flex-wrap">
+                  {overlayMode === "clinvar" && (
+                    <>
+                      <span className="text-xs text-slate-400">Group by</span>
+                      <Select
+                        value={clinvarGroupBy}
+                        onValueChange={setClinvarGroupBy}
+                      >
+                        <SelectTrigger className="h-7 w-[120px] text-xs bg-white">
+                          <SelectValue placeholder="Select" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Variants</SelectItem>
+                          <SelectItem value="significance">
+                            Clinical Significance
+                          </SelectItem>
+                          <SelectItem value="disease">Disease Type</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {clinvarGroupBy !== "all" && (
+                        <>
+                          {clinvarGroupBy === "significance" && (
+                            <>
+                              <span className="text-xs text-slate-400">
+                                Significance
+                              </span>
+                              <Select
+                                value={selectedClinicalSig}
+                                onValueChange={setSelectedClinicalSig}
+                              >
+                                <SelectTrigger className="h-7 w-[130px] text-xs bg-white">
+                                  <SelectValue placeholder="Select" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="all">All</SelectItem>
+                                  {clinicalSignificances.map((sig) => (
+                                    <SelectItem key={sig} value={sig}>
+                                      {sig}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </>
+                          )}
+                          {clinvarGroupBy === "disease" && (
+                            <>
+                              <span className="text-xs text-slate-400">
+                                Disease
+                              </span>
+                              <Select
+                                value={selectedDiseaseType}
+                                onValueChange={setSelectedDiseaseType}
+                              >
+                                <SelectTrigger className="h-7 w-[140px] text-xs bg-white">
+                                  <SelectValue placeholder="Select" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="all">
+                                    All Diseases
+                                  </SelectItem>
+                                  {diseaseTypes.map((disease) => (
+                                    <SelectItem key={disease} value={disease}>
+                                      {disease}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </>
+                          )}
+                          <span className="text-xs text-slate-400">
+                            Zygosity
+                          </span>
+                          <Select
+                            value={selectedZygosity}
+                            onValueChange={setSelectedZygosity}
+                          >
+                            <SelectTrigger className="h-7 w-[140px] text-xs bg-white">
+                              <SelectValue placeholder="Select" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="all">
+                                All Zygosities
+                              </SelectItem>
+                              <SelectItem value="het">Dominant</SelectItem>
+                              <SelectItem value="hom">
+                                Biallelic (Hom.)
+                              </SelectItem>
+                              <SelectItem value="biallelic">
+                                Biallelic (Compound Het.)
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </>
+                      )}
+                    </>
+                  )}
+                  {overlayMode === "gnomad" && (
+                    <>
+                      <span className="text-xs text-slate-400">Source</span>
+                      <Select
+                        value={selectedPopulationSource}
+                        onValueChange={setSelectedPopulationSource}
+                      >
+                        <SelectTrigger className="h-7 w-[140px] text-xs bg-white">
+                          <SelectValue placeholder="Select" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Sources</SelectItem>
+                          <SelectItem value="gnomad">gnomAD v4.1</SelectItem>
+                          <SelectItem value="aou">All of Us</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </>
+                  )}
+                  {overlayMode === "depletion_group" && (
+                    <div className="flex items-center gap-3 text-xs">
+                      <div className="flex items-center gap-1">
+                        <div className="w-2.5 h-2.5 rounded bg-red-500" />
+                        <span className="text-slate-600">Strong</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <div className="w-2.5 h-2.5 rounded bg-amber-500" />
+                        <span className="text-slate-600">Moderate</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <div className="w-2.5 h-2.5 rounded bg-emerald-500" />
+                        <span className="text-slate-600">Normal</span>
+                      </div>
+                    </div>
+                  )}
                 </div>
-              </ToggleGroupItem>
-              <ToggleGroupItem
-                value="depletion_group"
-                className="h-9 px-3 text-xs font-medium rounded-md border border-slate-200 hover:bg-slate-50 data-[state=on]:bg-orange-50 data-[state=on]:border-orange-200 data-[state=on]:text-orange-700"
-              >
-                <div className="flex items-center gap-1.5">
-                  <div className="flex gap-0.5">
-                    <div className="w-1 h-3 bg-red-400 rounded-sm"></div>
-                    <div className="w-1 h-2 bg-amber-400 rounded-sm"></div>
-                    <div className="w-1 h-1 bg-green-400 rounded-sm"></div>
-                  </div>
-                  Depletion Group
-                </div>
-              </ToggleGroupItem>
-            </ToggleGroup>
-          )}
-        </div>
+              </div>
+            )}
+          </div>
+        )}
 
         {!show3D && (
           <>
@@ -884,11 +1033,9 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                   ? "ClinVar Legend:"
                   : overlayMode === "gnomad"
                     ? "gnomAD Legend:"
-                    : overlayMode === "function_score"
-                      ? "Function Score Legend:"
-                      : overlayMode === "depletion_group"
-                        ? "Depletion Group Legend:"
-                        : "Legend:"}
+                    : overlayMode === "depletion_group"
+                      ? "Depletion Group Legend:"
+                      : "Legend:"}
               </div>
               <div className="flex flex-wrap gap-4 text-xs">
                 {overlayMode === "clinvar" ? (
@@ -956,30 +1103,6 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                         }}
                       ></div>
                       <span>High frequency</span>
-                    </div>
-                  </>
-                ) : overlayMode === "function_score" ? (
-                  <>
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-4 h-4 rounded-sm"
-                        style={{ backgroundColor: getFunctionScoreColor(-3) }}
-                      ></div>
-                      <span>Highly Depleted (-3)</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-4 h-4 rounded-sm"
-                        style={{ backgroundColor: getFunctionScoreColor(0) }}
-                      ></div>
-                      <span>Moderately Depleted (0)</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-4 h-4 rounded-sm"
-                        style={{ backgroundColor: getFunctionScoreColor(3) }}
-                      ></div>
-                      <span>Neutral (+3)</span>
                     </div>
                   </>
                 ) : overlayMode === "depletion_group" ? (

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -13,11 +13,6 @@ import {
 } from "lucide-react";
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   COLORBLIND_FRIENDLY_PALETTE,
   generateGnomadColorWithAlpha,
 } from "../../lib/colors";
@@ -35,6 +30,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import "./RNAViewer.css";
 import {
   getDistinctDiseaseTypes,

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -644,100 +644,140 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
               </div>
             </div>
 
-            {/* Filters */}
-            {overlayMode === "clinvar" && (
-              <div className="flex items-center gap-2 pt-2 border-t border-slate-100">
-                <Select
-                  value={clinvarGroupBy}
-                  onValueChange={setClinvarGroupBy}
-                >
-                  <SelectTrigger className="h-7 w-28 text-xs bg-white">
-                    <SelectValue placeholder="All" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="significance">Significance</SelectItem>
-                    <SelectItem value="disease">Disease</SelectItem>
-                  </SelectContent>
-                </Select>
-                {clinvarGroupBy !== "all" && (
-                  <Select
-                    value={
-                      clinvarGroupBy === "significance"
-                        ? selectedClinicalSig
-                        : selectedDiseaseType
-                    }
-                    onValueChange={
-                      clinvarGroupBy === "significance"
-                        ? setSelectedClinicalSig
-                        : setSelectedDiseaseType
-                    }
-                  >
-                    <SelectTrigger className="h-7 w-32 text-xs bg-white">
-                      <SelectValue placeholder="All" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All</SelectItem>
-                      {clinvarGroupBy === "significance"
-                        ? clinicalSignificances.map((sig) => (
-                            <SelectItem key={sig} value={sig}>
-                              {sig}
-                            </SelectItem>
-                          ))
-                        : diseaseTypes.map((disease) => (
-                            <SelectItem key={disease} value={disease}>
-                              {disease}
-                            </SelectItem>
-                          ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                <Select
-                  value={selectedZygosity}
-                  onValueChange={setSelectedZygosity}
-                >
-                  <SelectTrigger className="h-7 w-28 text-xs bg-white">
-                    <SelectValue placeholder="All" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="het">Dominant</SelectItem>
-                    <SelectItem value="hom">Biallelic</SelectItem>
-                    <SelectItem value="biallelic">Compound Het.</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-            {overlayMode === "gnomad" && (
-              <div className="flex items-center gap-2 pt-2 border-t border-slate-100">
-                <Select
-                  value={selectedPopulationSource}
-                  onValueChange={setSelectedPopulationSource}
-                >
-                  <SelectTrigger className="h-7 w-32 text-xs bg-white">
-                    <SelectValue placeholder="All" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    <SelectItem value="gnomad">gnomAD</SelectItem>
-                    <SelectItem value="aou">All of Us</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-            {overlayMode === "depletion_group" && (
-              <div className="flex items-center gap-3 pt-2 border-t border-slate-100 text-xs">
-                <div className="flex items-center gap-1">
-                  <div className="w-2.5 h-2.5 rounded bg-red-500" />
-                  <span className="text-slate-600">Strong</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <div className="w-2.5 h-2.5 rounded bg-amber-500" />
-                  <span className="text-slate-600">Moderate</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <div className="w-2.5 h-2.5 rounded bg-emerald-500" />
-                  <span className="text-slate-600">Normal</span>
+            {/* Current mode label and filters */}
+            {overlayMode !== "none" && (
+              <div className="flex items-center gap-2 pt-2 border-t border-slate-100 min-w-0">
+                <span className="text-xs font-medium text-slate-500 shrink-0">
+                  Filter:
+                </span>
+                <div className="flex items-center gap-2 flex-wrap">
+                  {overlayMode === "clinvar" && (
+                    <>
+                      <span className="text-xs font-medium text-slate-500">
+                        Group by
+                      </span>
+                      <Select
+                        value={clinvarGroupBy}
+                        onValueChange={setClinvarGroupBy}
+                      >
+                        <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                          <SelectValue placeholder="All" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All</SelectItem>
+                          <SelectItem value="significance">
+                            Significance
+                          </SelectItem>
+                          <SelectItem value="disease">Disease</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {clinvarGroupBy !== "all" && (
+                        <>
+                          {clinvarGroupBy === "significance" && (
+                            <>
+                              <span className="text-xs font-medium text-slate-500">
+                                Significance
+                              </span>
+                              <Select
+                                value={selectedClinicalSig}
+                                onValueChange={setSelectedClinicalSig}
+                              >
+                                <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                                  <SelectValue placeholder="All" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="all">All</SelectItem>
+                                  {clinicalSignificances.map((sig) => (
+                                    <SelectItem key={sig} value={sig}>
+                                      {sig}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </>
+                          )}
+                          {clinvarGroupBy === "disease" && (
+                            <>
+                              <span className="text-xs font-medium text-slate-500">
+                                Disease
+                              </span>
+                              <Select
+                                value={selectedDiseaseType}
+                                onValueChange={setSelectedDiseaseType}
+                              >
+                                <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                                  <SelectValue placeholder="All" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="all">All</SelectItem>
+                                  {diseaseTypes.map((disease) => (
+                                    <SelectItem key={disease} value={disease}>
+                                      {disease}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </>
+                          )}
+                          <span className="text-xs font-medium text-slate-500">
+                            Zygosity
+                          </span>
+                          <Select
+                            value={selectedZygosity}
+                            onValueChange={setSelectedZygosity}
+                          >
+                            <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                              <SelectValue placeholder="All" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="all">All</SelectItem>
+                              <SelectItem value="het">Dominant</SelectItem>
+                              <SelectItem value="hom">Biallelic</SelectItem>
+                              <SelectItem value="biallelic">
+                                Compound Het.
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </>
+                      )}
+                    </>
+                  )}
+                  {overlayMode === "gnomad" && (
+                    <>
+                      <span className="text-xs font-medium text-slate-500">
+                        Source
+                      </span>
+                      <Select
+                        value={selectedPopulationSource}
+                        onValueChange={setSelectedPopulationSource}
+                      >
+                        <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                          <SelectValue placeholder="All" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All</SelectItem>
+                          <SelectItem value="gnomad">gnomAD</SelectItem>
+                          <SelectItem value="aou">All of Us</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </>
+                  )}
+                  {overlayMode === "depletion_group" && (
+                    <div className="flex items-center gap-3 text-xs">
+                      <div className="flex items-center gap-1">
+                        <div className="w-2.5 h-2.5 rounded bg-red-500" />
+                        <span className="text-slate-600">Strong</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <div className="w-2.5 h-2.5 rounded bg-amber-500" />
+                        <span className="text-slate-600">Moderate</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <div className="w-2.5 h-2.5 rounded bg-emerald-500" />
+                        <span className="text-slate-600">Normal</span>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             )}

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -644,146 +644,100 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
               </div>
             </div>
 
-            {/* Current mode label and filters */}
-            {overlayMode !== "none" && (
-              <div className="flex items-center gap-2 pt-2 border-t border-slate-100 min-w-0">
-                <span className="text-xs font-medium text-slate-500 shrink-0">
-                  Filter:
-                </span>
-                <div className="flex items-center gap-2 flex-wrap">
-                  {overlayMode === "clinvar" && (
-                    <>
-                      <span className="text-xs font-medium text-slate-500">
-                        Group by
-                      </span>
-                      <Select
-                        value={clinvarGroupBy}
-                        onValueChange={setClinvarGroupBy}
-                      >
-                        <SelectTrigger className="h-7 w-[120px] text-xs bg-white">
-                          <SelectValue placeholder="Select" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="all">All Variants</SelectItem>
-                          <SelectItem value="significance">
-                            Clinical Significance
-                          </SelectItem>
-                          <SelectItem value="disease">Disease Type</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      {clinvarGroupBy !== "all" && (
-                        <>
-                          {clinvarGroupBy === "significance" && (
-                            <>
-                              <span className="text-xs font-medium text-slate-500">
-                                Significance
-                              </span>
-                              <Select
-                                value={selectedClinicalSig}
-                                onValueChange={setSelectedClinicalSig}
-                              >
-                                <SelectTrigger className="h-7 w-[130px] text-xs bg-white">
-                                  <SelectValue placeholder="Select" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="all">All</SelectItem>
-                                  {clinicalSignificances.map((sig) => (
-                                    <SelectItem key={sig} value={sig}>
-                                      {sig}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </>
-                          )}
-                          {clinvarGroupBy === "disease" && (
-                            <>
-                              <span className="text-xs font-medium text-slate-500">
-                                Disease
-                              </span>
-                              <Select
-                                value={selectedDiseaseType}
-                                onValueChange={setSelectedDiseaseType}
-                              >
-                                <SelectTrigger className="h-7 w-[140px] text-xs bg-white">
-                                  <SelectValue placeholder="Select" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="all">
-                                    All Diseases
-                                  </SelectItem>
-                                  {diseaseTypes.map((disease) => (
-                                    <SelectItem key={disease} value={disease}>
-                                      {disease}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </>
-                          )}
-                          <span className="text-xs font-medium text-slate-500">
-                            Zygosity
-                          </span>
-                          <Select
-                            value={selectedZygosity}
-                            onValueChange={setSelectedZygosity}
-                          >
-                            <SelectTrigger className="h-7 w-[140px] text-xs bg-white">
-                              <SelectValue placeholder="Select" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="all">
-                                All Zygosities
-                              </SelectItem>
-                              <SelectItem value="het">Dominant</SelectItem>
-                              <SelectItem value="hom">
-                                Biallelic (Hom.)
-                              </SelectItem>
-                              <SelectItem value="biallelic">
-                                Biallelic (Compound Het.)
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </>
-                      )}
-                    </>
-                  )}
-                  {overlayMode === "gnomad" && (
-                    <>
-                      <span className="text-xs font-medium text-slate-500">
-                        Source
-                      </span>
-                      <Select
-                        value={selectedPopulationSource}
-                        onValueChange={setSelectedPopulationSource}
-                      >
-                        <SelectTrigger className="h-7 w-[140px] text-xs bg-white">
-                          <SelectValue placeholder="Select" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="all">All Sources</SelectItem>
-                          <SelectItem value="gnomad">gnomAD v4.1</SelectItem>
-                          <SelectItem value="aou">All of Us</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </>
-                  )}
-                  {overlayMode === "depletion_group" && (
-                    <div className="flex items-center gap-3 text-xs">
-                      <div className="flex items-center gap-1">
-                        <div className="w-2.5 h-2.5 rounded bg-red-500" />
-                        <span className="text-slate-600">Strong</span>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <div className="w-2.5 h-2.5 rounded bg-amber-500" />
-                        <span className="text-slate-600">Moderate</span>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <div className="w-2.5 h-2.5 rounded bg-emerald-500" />
-                        <span className="text-slate-600">Normal</span>
-                      </div>
-                    </div>
-                  )}
+            {/* Filters */}
+            {overlayMode === "clinvar" && (
+              <div className="flex items-center gap-2 pt-2 border-t border-slate-100">
+                <Select
+                  value={clinvarGroupBy}
+                  onValueChange={setClinvarGroupBy}
+                >
+                  <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All</SelectItem>
+                    <SelectItem value="significance">Significance</SelectItem>
+                    <SelectItem value="disease">Disease</SelectItem>
+                  </SelectContent>
+                </Select>
+                {clinvarGroupBy !== "all" && (
+                  <Select
+                    value={
+                      clinvarGroupBy === "significance"
+                        ? selectedClinicalSig
+                        : selectedDiseaseType
+                    }
+                    onValueChange={
+                      clinvarGroupBy === "significance"
+                        ? setSelectedClinicalSig
+                        : setSelectedDiseaseType
+                    }
+                  >
+                    <SelectTrigger className="h-7 w-32 text-xs bg-white">
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      {clinvarGroupBy === "significance"
+                        ? clinicalSignificances.map((sig) => (
+                            <SelectItem key={sig} value={sig}>
+                              {sig}
+                            </SelectItem>
+                          ))
+                        : diseaseTypes.map((disease) => (
+                            <SelectItem key={disease} value={disease}>
+                              {disease}
+                            </SelectItem>
+                          ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <Select
+                  value={selectedZygosity}
+                  onValueChange={setSelectedZygosity}
+                >
+                  <SelectTrigger className="h-7 w-28 text-xs bg-white">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All</SelectItem>
+                    <SelectItem value="het">Dominant</SelectItem>
+                    <SelectItem value="hom">Biallelic</SelectItem>
+                    <SelectItem value="biallelic">Compound Het.</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {overlayMode === "gnomad" && (
+              <div className="flex items-center gap-2 pt-2 border-t border-slate-100">
+                <Select
+                  value={selectedPopulationSource}
+                  onValueChange={setSelectedPopulationSource}
+                >
+                  <SelectTrigger className="h-7 w-32 text-xs bg-white">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All</SelectItem>
+                    <SelectItem value="gnomad">gnomAD</SelectItem>
+                    <SelectItem value="aou">All of Us</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {overlayMode === "depletion_group" && (
+              <div className="flex items-center gap-3 pt-2 border-t border-slate-100 text-xs">
+                <div className="flex items-center gap-1">
+                  <div className="w-2.5 h-2.5 rounded bg-red-500" />
+                  <span className="text-slate-600">Strong</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-2.5 h-2.5 rounded bg-amber-500" />
+                  <span className="text-slate-600">Moderate</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <div className="w-2.5 h-2.5 rounded bg-emerald-500" />
+                  <span className="text-slate-600">Normal</span>
                 </div>
               </div>
             )}

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -13,6 +13,11 @@ import {
 } from "lucide-react";
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   COLORBLIND_FRIENDLY_PALETTE,
   generateGnomadColorWithAlpha,
 } from "../../lib/colors";
@@ -487,7 +492,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
         {!show3D && (
           <>
             <div className="flex items-center gap-3 bg-white px-3 py-2 rounded-md border border-slate-200">
-              <span className="text-sm text-slate-700 font-medium">
+              <span className="text-sm font-medium text-slate-500">
                 Structural Features
               </span>
               <Switch
@@ -515,96 +520,127 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
 
               {/* Mode toggle buttons - fixed width container */}
               <div className="flex items-center gap-1 shrink-0">
-                <button
-                  onClick={() => {
-                    if (overlayMode !== "none") {
-                      const cycles =
-                        [
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => {
+                        if (overlayMode !== "none") {
+                          const cycles =
+                            [
+                              "none",
+                              "clinvar",
+                              "gnomad",
+                              "depletion_group",
+                            ].indexOf("none") - cyclesFromMode(overlayMode);
+                          for (let i = 0; i < Math.abs(cycles || 1); i++)
+                            onCycleOverlay();
+                        }
+                      }}
+                      className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "none" ? "bg-slate-200 text-slate-800" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
+                    >
+                      <Ban className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">None</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Disable data overlay</p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => {
+                        const targetIndex = [
                           "none",
                           "clinvar",
                           "gnomad",
                           "depletion_group",
-                        ].indexOf("none") - cyclesFromMode(overlayMode);
-                      for (let i = 0; i < Math.abs(cycles || 1); i++)
-                        onCycleOverlay();
-                    }
-                  }}
-                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
-                    overlayMode === "none"
-                      ? "bg-slate-200 text-slate-800"
-                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-                  }`}
-                  title="Disable data overlay"
-                >
-                  <Ban className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">None</span>
-                </button>
-                <button
-                  onClick={() => {
-                    const targetIndex = [
-                      "none",
-                      "clinvar",
-                      "gnomad",
-                      "depletion_group",
-                    ].indexOf("clinvar");
-                    const current = cyclesFromMode(overlayMode);
-                    for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
-                      onCycleOverlay();
-                  }}
-                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
-                    overlayMode === "clinvar"
-                      ? "bg-red-100 text-red-700"
-                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-                  }`}
-                  title="Show ClinVar clinical variants with pathogenicity classifications"
-                >
-                  <AlertTriangle className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">Clinical Variants</span>
-                </button>
-                <button
-                  onClick={() => {
-                    const targetIndex = [
-                      "none",
-                      "clinvar",
-                      "gnomad",
-                      "depletion_group",
-                    ].indexOf("gnomad");
-                    const current = cyclesFromMode(overlayMode);
-                    for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
-                      onCycleOverlay();
-                  }}
-                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
-                    overlayMode === "gnomad"
-                      ? "bg-blue-100 text-blue-700"
-                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-                  }`}
-                  title="Show population frequency data from gnomAD and All of Us"
-                >
-                  <Users className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">Population Variants</span>
-                </button>
-                <button
-                  onClick={() => {
-                    const targetIndex = [
-                      "none",
-                      "clinvar",
-                      "gnomad",
-                      "depletion_group",
-                    ].indexOf("depletion_group");
-                    const current = cyclesFromMode(overlayMode);
-                    for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
-                      onCycleOverlay();
-                  }}
-                  className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${
-                    overlayMode === "depletion_group"
-                      ? "bg-orange-100 text-orange-700"
-                      : "bg-slate-100 text-slate-500 hover:bg-slate-200"
-                  }`}
-                  title="Show depletion group categories: Strong, Moderate, Normal"
-                >
-                  <Activity className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">Depletion</span>
-                </button>
+                        ].indexOf("clinvar");
+                        const current = cyclesFromMode(overlayMode);
+                        for (
+                          let i = 0;
+                          i < (targetIndex - current + 4) % 4;
+                          i++
+                        )
+                          onCycleOverlay();
+                      }}
+                      className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "clinvar" ? "bg-red-100 text-red-700" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
+                    >
+                      <AlertTriangle className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">
+                        Clinical Variants
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Show ClinVar clinical variants with pathogenicity
+                      classifications
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => {
+                        const targetIndex = [
+                          "none",
+                          "clinvar",
+                          "gnomad",
+                          "depletion_group",
+                        ].indexOf("gnomad");
+                        const current = cyclesFromMode(overlayMode);
+                        for (
+                          let i = 0;
+                          i < (targetIndex - current + 4) % 4;
+                          i++
+                        )
+                          onCycleOverlay();
+                      }}
+                      className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "gnomad" ? "bg-blue-100 text-blue-700" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
+                    >
+                      <Users className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">
+                        Population Variants
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Show population frequency data from gnomAD and All of Us
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => {
+                        const targetIndex = [
+                          "none",
+                          "clinvar",
+                          "gnomad",
+                          "depletion_group",
+                        ].indexOf("depletion_group");
+                        const current = cyclesFromMode(overlayMode);
+                        for (
+                          let i = 0;
+                          i < (targetIndex - current + 4) % 4;
+                          i++
+                        )
+                          onCycleOverlay();
+                      }}
+                      className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "depletion_group" ? "bg-orange-100 text-orange-700" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
+                    >
+                      <Activity className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">Depletion</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Show depletion group categories: Strong, Moderate, Normal
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
               </div>
             </div>
 
@@ -617,7 +653,9 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                 <div className="flex items-center gap-2 flex-wrap">
                   {overlayMode === "clinvar" && (
                     <>
-                      <span className="text-xs text-slate-400">Group by</span>
+                      <span className="text-xs font-medium text-slate-500">
+                        Group by
+                      </span>
                       <Select
                         value={clinvarGroupBy}
                         onValueChange={setClinvarGroupBy}
@@ -637,7 +675,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                         <>
                           {clinvarGroupBy === "significance" && (
                             <>
-                              <span className="text-xs text-slate-400">
+                              <span className="text-xs font-medium text-slate-500">
                                 Significance
                               </span>
                               <Select
@@ -660,7 +698,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                           )}
                           {clinvarGroupBy === "disease" && (
                             <>
-                              <span className="text-xs text-slate-400">
+                              <span className="text-xs font-medium text-slate-500">
                                 Disease
                               </span>
                               <Select
@@ -683,7 +721,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                               </Select>
                             </>
                           )}
-                          <span className="text-xs text-slate-400">
+                          <span className="text-xs font-medium text-slate-500">
                             Zygosity
                           </span>
                           <Select
@@ -712,7 +750,9 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                   )}
                   {overlayMode === "gnomad" && (
                     <>
-                      <span className="text-xs text-slate-400">Source</span>
+                      <span className="text-xs font-medium text-slate-500">
+                        Source
+                      </span>
                       <Select
                         value={selectedPopulationSource}
                         onValueChange={setSelectedPopulationSource}

--- a/src/components/VariantLiteratureCard.tsx
+++ b/src/components/VariantLiteratureCard.tsx
@@ -28,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { COLORBLIND_FRIENDLY_PALETTE } from "@/lib/colors";
 import type { Variant, Literature, LiteratureCounts } from "@/types";
 
 interface VariantLiteratureCardProps {
@@ -275,17 +276,49 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
 
   const getClinicalBadge = (clinical: string) => {
     const lower = clinical?.toLowerCase() || "";
-    if (lower.includes("pathogenic") && !lower.includes("likely"))
-      return "bg-red-100 text-red-800 border-red-200";
-    if (lower.includes("likely pathogenic") || lower === "lp")
-      return "bg-orange-100 text-orange-800 border-orange-200";
-    if (lower.includes("benign") && !lower.includes("likely"))
-      return "bg-emerald-100 text-emerald-800 border-emerald-200";
-    if (lower.includes("likely benign") || lower === "lb")
-      return "bg-green-100 text-green-800 border-green-200";
-    if (lower.includes("vus") || lower.includes("uncertain"))
-      return "bg-amber-100 text-amber-800 border-amber-200";
-    return "bg-slate-100 text-slate-800 border-slate-200";
+    if (lower.includes("pathogenic") && !lower.includes("likely")) {
+      return {
+        backgroundColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.PATHOGENIC + "20",
+        color: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.PATHOGENIC,
+        borderColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.PATHOGENIC + "40",
+      };
+    }
+    if (lower.includes("likely pathogenic") || lower === "lp") {
+      return {
+        backgroundColor:
+          COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_PATHOGENIC + "20",
+        color: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_PATHOGENIC,
+        borderColor:
+          COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_PATHOGENIC + "40",
+      };
+    }
+    if (lower.includes("benign") && !lower.includes("likely")) {
+      return {
+        backgroundColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.BENIGN + "20",
+        color: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.BENIGN,
+        borderColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.BENIGN + "40",
+      };
+    }
+    if (lower.includes("likely benign") || lower === "lb") {
+      return {
+        backgroundColor:
+          COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_BENIGN + "20",
+        color: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_BENIGN,
+        borderColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_BENIGN + "40",
+      };
+    }
+    if (lower.includes("vus") || lower.includes("uncertain")) {
+      return {
+        backgroundColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.VUS + "20",
+        color: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.VUS,
+        borderColor: COLORBLIND_FRIENDLY_PALETTE.CLINVAR.VUS + "40",
+      };
+    }
+    return {
+      backgroundColor: "#f1f5f9",
+      color: "#475569",
+      borderColor: "#e2e8f0",
+    };
   };
 
   const clearFilters = () => {
@@ -587,18 +620,19 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
                             {variant.hgvs || variant.id}
                           </td>
                           <td className="py-3 px-2">
-                            <span
-                              className={`text-xs px-1.5 py-0.5 rounded-full text-center font-medium ${getClinicalBadge(
+                            {(() => {
+                              const style = getClinicalBadge(
                                 variant.clinical_significance || "",
-                              )
-                                .replace("text-white", "text-")
-                                .replace(
-                                  "bg-slate-200",
-                                  "bg-slate-100 text-slate-700",
-                                )}`}
-                            >
-                              {variant.clinical_significance || "Unknown"}
-                            </span>
+                              );
+                              return (
+                                <span
+                                  className="text-xs px-1.5 py-0.5 rounded-full text-center font-medium"
+                                  style={style}
+                                >
+                                  {variant.clinical_significance || "Unknown"}
+                                </span>
+                              );
+                            })()}
                           </td>
                           <td className="py-3 px-2 text-slate-600 truncate">
                             {variant.disease_type || "—"}
@@ -1064,13 +1098,17 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
                                     {variant.ref}→{variant.alt}
                                   </span>
                                 )}
-                                {variant?.clinical_significance && (
-                                  <Badge
-                                    className={`text-xs ${getClinicalBadge(variant.clinical_significance)}`}
-                                  >
-                                    {variant.clinical_significance}
-                                  </Badge>
-                                )}
+                                {variant?.clinical_significance &&
+                                  (() => {
+                                    const style = getClinicalBadge(
+                                      variant.clinical_significance,
+                                    );
+                                    return (
+                                      <Badge className="text-xs" style={style}>
+                                        {variant.clinical_significance}
+                                      </Badge>
+                                    );
+                                  })()}
                               </div>
                             );
                           },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,21 +5,18 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-blue-500 focus-visible:ring-blue-500/50 focus-visible:ring-[3px]",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-blue-600 text-white shadow-xs hover:bg-blue-700",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-red-600 text-white shadow-xs hover:bg-red-700 focus-visible:ring-red-500/20",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "border border-slate-300 bg-white shadow-xs hover:bg-slate-100 hover:text-slate-900",
+        secondary: "bg-slate-200 text-slate-900 shadow-xs hover:bg-slate-300",
+        ghost: "hover:bg-slate-100 hover:text-slate-900",
+        link: "text-blue-600 underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-blue-500 focus-visible:ring-[3px] focus-visible:ring-blue-500/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-slate-400 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-slate-500",
         className,
       )}
       {...props}
@@ -60,7 +60,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-white text-slate-900 shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-slate-200 bg-white text-slate-900 shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -92,7 +92,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      className={cn("px-2 py-1.5 text-xs text-slate-500", className)}
       {...props}
     />
   );
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-slate-500 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}
@@ -132,7 +132,10 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      className={cn(
+        "pointer-events-none -mx-1 my-1 h-px bg-slate-200",
+        className,
+      )}
       {...props}
     />
   );

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-blue-500 focus-visible:ring-[3px] focus-visible:ring-blue-500/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-slate-400 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-slate-500",
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-blue-500 focus-visible:ring-[3px] focus-visible:ring-blue-500/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-slate-400 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-slate-500",
         className,
       )}
       {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 4,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-slate-900" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -31,14 +31,14 @@ const Gene: React.FC = () => {
   const [searchResults, setSearchResults] = useState<null | SnRNAGene[]>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [overlayMode, setOverlayMode] = useState<
-    "none" | "clinvar" | "gnomad" | "function_score" | "depletion_group"
-  >("none");
+    "none" | "clinvar" | "gnomad" | "depletion_group"
+  >("clinvar");
   const [functionScoreTrackData, setFunctionScoreTrackData] = useState({});
   const [depletionGroupTrackData, setDepletionGroupTrackData] = useState({});
   const [caddScoreTrackData, setCaddScoreTrackData] = useState({});
   const [clinvarOverlayData, setClinvarOverlayData] = useState({});
   const [gnomadOverlayData, setGnomadOverlayData] = useState({});
-  const [functionScoreOverlayData, setFunctionScoreOverlayData] = useState({});
+
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -109,31 +109,6 @@ const Gene: React.FC = () => {
   }, [geneId, selectedSnRNA]);
 
   useEffect(() => {
-    const createFunctionScoreTrackData = (variants: Variant[]) => {
-      return Object.fromEntries(
-        variants
-          .filter(
-            (v) =>
-              v.function_score !== undefined &&
-              v.function_score !== null &&
-              v.nucleotidePosition !== undefined,
-          )
-          .map((v) => [
-            v.nucleotidePosition!,
-            {
-              value: v.function_score!, // Use actual raw values for line chart
-              label: `Function Score: ${v.function_score!.toFixed(3)}`,
-              color:
-                v.function_score! > 0
-                  ? COLORBLIND_FRIENDLY_PALETTE.DEPLETION.NORMAL // Green for beneficial (positive)
-                  : v.function_score! < -1
-                    ? COLORBLIND_FRIENDLY_PALETTE.DEPLETION.STRONG // Red for highly deleterious (< -1)
-                    : COLORBLIND_FRIENDLY_PALETTE.DEPLETION.MODERATE, // Orange for moderately deleterious (-1 to 0)
-            },
-          ]),
-      );
-    };
-
     const createDepletionGroupTrackData = (variants: Variant[]) => {
       return Object.fromEntries(
         variants
@@ -205,37 +180,28 @@ const Gene: React.FC = () => {
       );
     };
 
-    const createFunctionScoreOverlayData = (
-      variants: Variant[],
-      geneData: SnRNAGene,
-    ) => {
+    const createFunctionScoreTrackData = (variants: Variant[]) => {
       return Object.fromEntries(
         variants
           .filter(
             (v) =>
               v.function_score !== undefined &&
               v.function_score !== null &&
-              (v.nucleotidePosition !== undefined || v.position !== undefined),
+              v.nucleotidePosition !== undefined,
           )
-          .map((v) => {
-            // Get nucleotide position - either directly or convert from genomic position
-            let nucleotidePos = v.nucleotidePosition;
-            if (nucleotidePos === undefined && v.position !== undefined) {
-              if (geneData.strand === "-") {
-                nucleotidePos = geneData.end - v.position + 1;
-              } else {
-                nucleotidePos = v.position - geneData.start + 1;
-              }
-            }
-            return [
-              nucleotidePos!,
-              {
-                value: v.function_score!, // Use actual continuous values for overlay
-                label: `Function Score: ${v.function_score!.toFixed(3)}`,
-                variantId: v.id,
-              },
-            ];
-          }),
+          .map((v) => [
+            v.nucleotidePosition!,
+            {
+              value: v.function_score!,
+              label: `Function Score: ${v.function_score!.toFixed(3)}`,
+              color:
+                v.function_score! > 0
+                  ? COLORBLIND_FRIENDLY_PALETTE.DEPLETION.NORMAL
+                  : v.function_score! < -1
+                    ? COLORBLIND_FRIENDLY_PALETTE.DEPLETION.STRONG
+                    : COLORBLIND_FRIENDLY_PALETTE.DEPLETION.MODERATE,
+            },
+          ]),
       );
     };
 
@@ -323,15 +289,11 @@ const Gene: React.FC = () => {
     const gnomadData = currentData
       ? createGnomadOverlayData(variantData, currentData)
       : {};
-    const functionScoreOverlayData = currentData
-      ? createFunctionScoreOverlayData(variantData, currentData)
-      : {};
     setFunctionScoreTrackData(funcScoreData);
     setDepletionGroupTrackData(depletionData);
     setCaddScoreTrackData(caddData);
     setClinvarOverlayData(clinvarData);
     setGnomadOverlayData(gnomadData);
-    setFunctionScoreOverlayData(functionScoreOverlayData);
   }, [variantData, currentData]);
 
   const cycleOverlayMode = () => {
@@ -342,13 +304,11 @@ const Gene: React.FC = () => {
         case "clinvar":
           return "gnomad";
         case "gnomad":
-          return "function_score";
-        case "function_score":
           return "depletion_group";
         case "depletion_group":
           return "none";
         default:
-          return "none";
+          return "clinvar";
       }
     });
   };
@@ -359,8 +319,6 @@ const Gene: React.FC = () => {
         return clinvarOverlayData;
       case "gnomad":
         return gnomadOverlayData;
-      case "function_score":
-        return functionScoreOverlayData; // Use continuous overlay data
       case "depletion_group":
         return depletionGroupTrackData;
       default:

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,7 @@ dependencies = [
     { name = "authlib" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "orjson" },
     { name = "pandas" },
     { name = "pyjwt" },
@@ -74,6 +75,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.3.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "orjson", specifier = ">=3.11.3" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
@@ -323,6 +325,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add shadcn Tooltip component for hover tooltips on Data Overlay buttons
- Fix Select and Button component colors with explicit Tailwind slate classes
- Streamline filter dropdowns with cleaner placeholders and shorter labels
- Unify filter label styles across the Data Overlay panel

## Changes
- New tooltip component with proper slate-900 styling
- TooltipProvider wraps the app
- Select dropdowns use text-slate-700 for better contrast
- Button variants use explicit colors instead of CSS variables
- Filter dropdowns now use "All" placeholder instead of "Select"
- Shorter, consistent labels across all dropdowns