### PR TITLE
Add Slack webhook notifications for approvals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,11 @@ ADMIN_GITHUB_LOGINS=username1,username2
 # Frontend URL - Used for OAuth callback redirects
 # Use http://localhost:5173 for local development
 FRONTEND_URL=http://localhost:5173
+
+# Slack Webhook Notifications
+# Enable/disable Slack notifications (set to "true" to enable)
+SLACK_ENABLED=false
+# Webhook URL from https://api.slack.com/messaging/webhooks
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
+# Optional: Override default channel (default: #general)
+SLACK_DEFAULT_CHANNEL=#rnudb-alerts

--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
 
 from .routers import genes, literature, variants
+from .routers.admin import router as admin_router
 from .routers.approvals import router as approvals_router
 from .routers.auth import router as auth_router
 from .routers.bed_tracks import router as bed_tracks_router
@@ -46,6 +47,7 @@ app.include_router(users_router, prefix="/api/users")
 app.include_router(imports_router, prefix="/api")
 app.include_router(bed_tracks_router, prefix="/api")
 app.include_router(approvals_router, prefix="/api")
+app.include_router(admin_router, prefix="/api")
 
 # Serve frontend static files
 dist_path = Path(__file__).resolve().parent.parent / "dist"

--- a/api/notifications/__init__.py
+++ b/api/notifications/__init__.py
@@ -1,0 +1,16 @@
+"""Notifications module."""
+from api.notifications.slack import (
+    is_enabled,
+    notify_change_approved,
+    notify_change_rejected,
+    notify_test,
+    notify_user_approved,
+)
+
+__all__ = [
+    "notify_user_approved",
+    "notify_change_approved",
+    "notify_change_rejected",
+    "notify_test",
+    "is_enabled",
+]

--- a/api/notifications/__init__.py
+++ b/api/notifications/__init__.py
@@ -1,4 +1,5 @@
 """Notifications module."""
+
 from api.notifications.slack import (
     is_enabled,
     notify_change_approved,

--- a/api/notifications/slack.py
+++ b/api/notifications/slack.py
@@ -1,7 +1,7 @@
 """Slack webhook notifications for approvals."""
 
-import os
 import logging
+import os
 from datetime import datetime
 
 import httpx
@@ -34,7 +34,10 @@ def _send_webhook(message: str) -> bool:
 
 def notify_user_approved(github_login: str, approved_by: str) -> bool:
     """Notify when a user is approved."""
-    message = f"🔔 User Approved\n• @{github_login} promoted to curator\n• By: @{approved_by}"
+    message = (
+        f"🔔 User Approved\n• @{github_login} promoted to curator\n"
+        f"• By: @{approved_by}"
+    )
     return _send_webhook(message)
 
 
@@ -58,13 +61,20 @@ def notify_change_rejected(
 ) -> bool:
     """Notify when a data change is rejected."""
     reason_text = f"\n• Reason: {reason}" if reason else ""
-    message = f"📝 Change Rejected\n• {entity_type} - {action}\n• By: @{rejected_by}{reason_text}"
-    return _send_webhook(message)
+    msg = (
+        f"📝 Change Rejected\n• {entity_type} - {action}\n"
+        f"• By: @{rejected_by}{reason_text}"
+    )
+    return _send_webhook(msg)
 
 
 def notify_test() -> bool:
     """Send a test notification."""
-    message = f"🧪 Test Notification\n• RNUdb Slack integration is working!\n• Time: {datetime.now().isoformat()}"
+    message = (
+        f"🧪 Test Notification\n"
+        f"• RNUdb Slack integration is working!\n"
+        f"• Time: {datetime.now().isoformat()}"
+    )
     return _send_webhook(message)
 
 

--- a/api/notifications/slack.py
+++ b/api/notifications/slack.py
@@ -1,0 +1,73 @@
+"""Slack webhook notifications for approvals."""
+
+import os
+import logging
+from datetime import datetime
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+SLACK_ENABLED = os.environ.get("SLACK_ENABLED", "false").lower() == "true"
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+SLACK_DEFAULT_CHANNEL = os.environ.get("SLACK_DEFAULT_CHANNEL", "#general")
+
+
+def _send_webhook(message: str) -> bool:
+    """Send message to Slack webhook. Returns True on success, False on failure."""
+    if not SLACK_ENABLED or not SLACK_WEBHOOK_URL:
+        return False
+
+    try:
+        payload = {
+            "text": message,
+            "channel": SLACK_DEFAULT_CHANNEL,
+        }
+        with httpx.Client(timeout=10) as client:
+            response = client.post(SLACK_WEBHOOK_URL, json=payload)
+            response.raise_for_status()
+            return True
+    except Exception as e:
+        logger.warning(f"Failed to send Slack notification: {e}")
+        return False
+
+
+def notify_user_approved(github_login: str, approved_by: str) -> bool:
+    """Notify when a user is approved."""
+    message = f"🔔 User Approved\n• @{github_login} promoted to curator\n• By: @{approved_by}"
+    return _send_webhook(message)
+
+
+def notify_change_approved(
+    entity_type: str,
+    action: str,
+    requested_by: str,
+    approved_by: str,
+) -> bool:
+    """Notify when a data change is approved."""
+    message = f"📝 Change Approved\n• {entity_type} - {action}\n• By: @{approved_by}"
+    return _send_webhook(message)
+
+
+def notify_change_rejected(
+    entity_type: str,
+    action: str,
+    requested_by: str,
+    rejected_by: str,
+    reason: str | None = None,
+) -> bool:
+    """Notify when a data change is rejected."""
+    reason_text = f"\n• Reason: {reason}" if reason else ""
+    message = f"📝 Change Rejected\n• {entity_type} - {action}\n• By: @{rejected_by}{reason_text}"
+    return _send_webhook(message)
+
+
+def notify_test() -> bool:
+    """Send a test notification."""
+    message = f"🧪 Test Notification\n• RNUdb Slack integration is working!\n• Time: {datetime.now().isoformat()}"
+    return _send_webhook(message)
+
+
+def is_enabled() -> bool:
+    """Check if Slack notifications are enabled."""
+    return SLACK_ENABLED and bool(SLACK_WEBHOOK_URL)

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -1,0 +1,21 @@
+"""Admin utilities router."""
+
+from fastapi import APIRouter, Depends
+
+from api.notifications import is_enabled, notify_test
+from api.routers.auth import require_admin
+
+router = APIRouter(prefix="/admin")
+
+
+@router.get("/slack/status")
+async def get_slack_status(user: dict = Depends(require_admin)) -> dict:
+    """Get Slack integration status."""
+    return {"enabled": is_enabled()}
+
+
+@router.post("/slack/test")
+async def test_slack_notification(user: dict = Depends(require_admin)) -> dict:
+    """Send a test Slack notification."""
+    success = notify_test()
+    return {"success": success, "message": "Test notification sent" if success else "Slack not configured"}

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -18,4 +18,5 @@ async def get_slack_status(user: dict = Depends(require_admin)) -> dict:
 async def test_slack_notification(user: dict = Depends(require_admin)) -> dict:
     """Send a test Slack notification."""
     success = notify_test()
-    return {"success": success, "message": "Test notification sent" if success else "Slack not configured"}
+    msg = "Test notification sent" if success else "Slack not configured"
+    return {"success": success, "message": msg}

--- a/api/routers/approvals.py
+++ b/api/routers/approvals.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from sqlmodel import SQLModel
 
 from api.models import PendingChange, PendingChangeOut
+from api.notifications import notify_change_approved, notify_change_rejected
 from api.routers.auth import require_admin, require_curator
 from rnudb_utils.database import get_db
 
@@ -177,6 +178,23 @@ async def review_change(
     change.review_notes = body.notes
     db.commit()
     db.refresh(change)
+
+    # Send Slack notification (fail silently)
+    if body.status == "approved":
+        notify_change_approved(
+            change.entity_type,
+            change.action,
+            change.requested_by,
+            user["github_login"],
+        )
+    elif body.status == "rejected":
+        notify_change_rejected(
+            change.entity_type,
+            change.action,
+            change.requested_by,
+            user["github_login"],
+            body.notes,
+        )
 
     return _row_to_dict(change)
 

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
+from api.notifications import notify_user_approved
 from api.routers.auth import require_admin
 from rnudb_utils.database import (
     list_all_users,
@@ -49,10 +50,13 @@ async def get_pending_users(request: Request):
 
 
 @router.post("/users/{github_login}/approve")
-async def approve_user(github_login: str, request: Request):
+async def approve_user(
+    github_login: str,
+    user: dict = Depends(require_admin),
+):
     """Approve a pending user as curator (admin only)."""
-    require_admin(request)
     update_user_role(github_login, "curator")
+    notify_user_approved(github_login, user.get("github_login", "admin"))
     return {"message": f"User {github_login} approved as curator"}
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -53,13 +53,16 @@ The Docker image mounts `/app/data` for persistent storage:
 
 ### Environment Variables
 
-| Variable               | Required | Description                            |
-| ---------------------- | -------- | -------------------------------------- |
-| `GITHUB_CLIENT_ID`     | Yes      | GitHub OAuth App client ID             |
-| `GITHUB_CLIENT_SECRET` | Yes      | GitHub OAuth App client secret         |
-| `JWT_SECRET_KEY`       | Yes      | Secret for JWT signing (min 32 chars)  |
-| `ADMIN_GITHUB_LOGINS`  | Yes      | Comma-separated admin GitHub usernames |
-| `FRONTEND_URL`         | Yes      | Production URL for OAuth callbacks     |
+| Variable                | Required | Description                                         |
+| ----------------------- | -------- | --------------------------------------------------- |
+| `GITHUB_CLIENT_ID`      | Yes      | GitHub OAuth App client ID                          |
+| `GITHUB_CLIENT_SECRET`  | Yes      | GitHub OAuth App client secret                      |
+| `JWT_SECRET_KEY`        | Yes      | Secret for JWT signing (min 32 chars)               |
+| `ADMIN_GITHUB_LOGINS`   | Yes      | Comma-separated admin GitHub usernames              |
+| `FRONTEND_URL`          | Yes      | Production URL for OAuth callbacks                  |
+| `SLACK_ENABLED`         | No       | Enable Slack notifications (true/false)             |
+| `SLACK_WEBHOOK_URL`     | No       | Slack webhook URL for notifications                 |
+| `SLACK_DEFAULT_CHANNEL` | No       | Slack channel for notifications (default: #general) |
 
 ---
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,11 +13,12 @@ import {
   BookOpen,
   Search,
 } from "lucide-react";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { getAllSnRNAIds, getGeneData } from "../data/genes";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { SnRNAGene } from "@/types";
@@ -51,6 +52,25 @@ const Header: React.FC<HeaderProps> = ({
     login,
     logout,
   } = useAuth();
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    if (isAdmin) {
+      Promise.all([
+        fetch("/api/users/pending", { credentials: "include" }).then((r) =>
+          r.json(),
+        ),
+        fetch("/api/approvals?status=pending", { credentials: "include" }).then(
+          (r) => r.json(),
+        ),
+      ])
+        .then(([users, changes]) => {
+          const count = (users?.length || 0) + (changes?.length || 0);
+          setPendingCount(count);
+        })
+        .catch(() => {});
+    }
+  }, [isAdmin]);
 
   const handleSearch = async () => {
     if (searchTerm.trim()) {
@@ -124,10 +144,18 @@ const Header: React.FC<HeaderProps> = ({
                 variant="ghost"
                 size="sm"
                 onClick={() => navigate("/admin")}
-                className="text-slate-600 hover:text-teal-600 hover:bg-teal-50"
+                className="text-slate-600 hover:text-teal-600 hover:bg-teal-50 relative"
               >
                 <Shield className="h-4 w-4 mr-1.5" />
                 Admin
+                {pendingCount > 0 && (
+                  <Badge
+                    variant="destructive"
+                    className="absolute -top-1 -right-1 h-5 w-5 p-0 flex items-center justify-center text-[10px]"
+                  >
+                    {pendingCount > 9 ? "9+" : pendingCount}
+                  </Badge>
+                )}
               </Button>
             )}
             <div className="w-px h-5 bg-slate-200 mx-1" />
@@ -294,10 +322,18 @@ const Header: React.FC<HeaderProps> = ({
                   navigate("/admin");
                   setIsMobileMenuOpen(false);
                 }}
-                className="w-full justify-start text-slate-700"
+                className="w-full justify-start text-slate-700 relative"
               >
                 <Shield className="h-4 w-4 mr-2" />
                 Admin
+                {pendingCount > 0 && (
+                  <Badge
+                    variant="destructive"
+                    className="ml-auto h-5 w-5 p-0 flex items-center justify-center text-[10px]"
+                  >
+                    {pendingCount > 9 ? "9+" : pendingCount}
+                  </Badge>
+                )}
               </Button>
             )}
             <div className="border-t border-slate-100 my-2" />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Bell,
 } from "lucide-react";
 import React, { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -55,6 +56,9 @@ const Admin: React.FC = () => {
   const [expandedPayloads, setExpandedPayloads] = useState<Set<number>>(
     new Set(),
   );
+  const [slackEnabled, setSlackEnabled] = useState(false);
+  const [testSlackLoading, setTestSlackLoading] = useState(false);
+  const [testSlackResult, setTestSlackResult] = useState<string | null>(null);
   const {
     listChanges,
     reviewChange,
@@ -133,6 +137,32 @@ const Admin: React.FC = () => {
     await loadData();
   };
 
+  const handleTestSlack = async () => {
+    setTestSlackLoading(true);
+    setTestSlackResult(null);
+    try {
+      const res = await fetch("/api/admin/slack/test", {
+        method: "POST",
+        credentials: "include",
+      });
+      const data = await res.json();
+      setTestSlackResult(
+        data.success ? "Test notification sent!" : "Slack not configured",
+      );
+    } catch {
+      setTestSlackResult("Failed to send test");
+    } finally {
+      setTestSlackLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetch("/api/admin/slack/status", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => setSlackEnabled(data.enabled))
+      .catch(() => {});
+  }, []);
+
   const getEntityIcon = (type: string) => {
     switch (type) {
       case "variant":
@@ -191,6 +221,28 @@ const Admin: React.FC = () => {
             <p className="text-slate-500">
               Manage users, approvals, and system settings
             </p>
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleTestSlack}
+              disabled={testSlackLoading}
+            >
+              <Bell className="h-4 w-4 mr-1" />
+              {testSlackLoading ? "Sending..." : "Test Slack"}
+            </Button>
+            {testSlackResult && (
+              <span className="text-xs text-slate-600">{testSlackResult}</span>
+            )}
+            {slackEnabled && (
+              <Badge
+                variant="secondary"
+                className="bg-emerald-100 text-emerald-700"
+              >
+                Slack Enabled
+              </Badge>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Add Slack webhook notifications for:
- New user approvals
- Data change approvals/rejections
- Test button in Admin Dashboard
- Notification badge on Admin link in header
- Feature flag to enable/disable

## Changes

### Backend
- New `api/notifications/slack.py` module with webhook integration
- Notifications triggered on:
  - User approval (`api/routers/users.py`)
  - Change approval/rejection (`api/routers/approvals.py`)
- New admin endpoints for Slack status and test notification
- Fail silently - approval succeeds even if webhook fails

### Frontend
- Test Slack button in Admin Dashboard
- Notification badge on Admin link in header (shows pending count)

### Configuration
New environment variables:
- `SLACK_ENABLED` (bool) - Enable/disable notifications
- `SLACK_WEBHOOK_URL` - Slack webhook URL
- `SLACK_DEFAULT_CHANNEL` - Channel for notifications (default: #general)

## Testing
- All existing tests pass
- E2E tests pass
- Pre-commit hooks pass

## Related Issue
Closes #45