### PR TITLE
Fix Dependabot schedule day configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "first"
+      day: "monday"
     open-pull-requests-limit: 10
     auto-merge-method: "squash"
     auto-assign: true
@@ -24,7 +24,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "first"
+      day: "monday"
     open-pull-requests-limit: 10
     auto-merge-method: "squash"
     auto-assign: true


### PR DESCRIPTION
## Summary
Fix Dependabot configuration - `day: "first"` is invalid.

## Changes
- Changed `day: "first"` to `day: "monday"` in `.github/dependabot.yml`
- Dependabot requires a specific day of the week, not "first"

## Testing
- Dependabot will now parse the config correctly

## Related Issue
Fixes CI failure on PR #47