### PR TITLE
Fix Dependabot config - remove invalid properties

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
       interval: "monthly"
       day: "monday"
     open-pull-requests-limit: 10
-    auto-merge-method: "squash"
-    auto-assign: true
     commit-message:
       prefix: "npm"
     labels:
@@ -26,8 +24,6 @@ updates:
       interval: "monthly"
       day: "monday"
     open-pull-requests-limit: 10
-    auto-merge-method: "squash"
-    auto-assign: true
     commit-message:
       prefix: "pip"
     labels:


### PR DESCRIPTION
## Summary
Fix Dependabot configuration by removing invalid properties that caused CI failure.

## Changes
- Removed `auto-merge-method: "squash"` (not a valid Dependabot option)
- Removed `auto-assign: true` (not a valid Dependabot option)

## Note
- Auto-merge must be enabled in repo Settings → General → Pull Requests → "Allow auto-merge"
- Auto-assign is not a config option in Dependabot

## Related Issue
Fixes CI failure on PR #47 and #50