### PR TITLE
Simplify zygosity filter dropdown

### DIFF
--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -172,8 +172,6 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
           if (selectedZygosity !== "all") {
             if (selectedZygosity === "het") {
               if (variant.zygosity !== "het") return false;
-            } else if (selectedZygosity === "hom") {
-              if (variant.zygosity !== "hom") return false;
             } else if (selectedZygosity === "biallelic") {
               const isBiallelic =
                 variant.zygosity === "hom" ||
@@ -732,9 +730,8 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                             <SelectContent>
                               <SelectItem value="all">All</SelectItem>
                               <SelectItem value="het">Dominant</SelectItem>
-                              <SelectItem value="hom">Biallelic</SelectItem>
                               <SelectItem value="biallelic">
-                                Compound Het.
+                                Biallelic
                               </SelectItem>
                             </SelectContent>
                           </Select>


### PR DESCRIPTION
## Summary
- Simplify the zygosity filter dropdown in the Gene Page RNA Viewer Data Overlay from 4 options to 3 options
- Remove redundant 'hom' option that was duplicating functionality
- Rename 'Compound Het.' to 'Biallelic' for clearer understanding

## Changes
| Before | After |
|--------|-------|
| All | All |
| Dominant (het) | Dominant (het) |
| Biallelic (hom) | Biallelic (hom OR compound het) |
| Compound Het. (biallelic) | *removed* |

## Details
- **Dominant**: Filters for heterozygous variants only (`zygosity = het`)
- **Biallelic**: Now correctly includes both homozygous variants AND compound heterozygous variants (recessive inheritance patterns)

## Testing
- Lint passes
- Build passes