### PR TITLE
fix: Use matrix with native runners for each platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
+            tag_suffix: linux-amd64
             runner: ubuntu-latest
           - platform: linux/arm64
+            tag_suffix: linux-arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
 
@@ -63,7 +65,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ replace(matrix.platform, '/', '-') }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.tag_suffix }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -22,9 +22,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.platform }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ replace(matrix.platform, '/', '-') }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -109,13 +109,13 @@ jobs:
         run: |
           docker manifest create \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux/amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux/arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-arm64
 
           docker manifest create \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux/amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux/arm64
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-arm64
 
           docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,17 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout
@@ -22,6 +29,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        if: matrix.platform == 'linux/amd64'
+        uses: docker/setup-qemu-action@v3
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -48,7 +59,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -57,4 +68,4 @@ jobs:
 
       - name: Image digest
         if: github.event_name != 'pull_request'
-        run: echo ${{ steps.meta.outputs.digest }}
+        run: echo "${{ matrix.platform }} digest: ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,10 @@ env:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            tag_suffix: linux-amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            tag_suffix: linux-arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout
@@ -32,8 +23,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU (only needed for amd64, not arm64 native)
-        if: matrix.platform == 'linux/amd64'
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to Container Registry
@@ -61,63 +51,13 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.tag_suffix }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Upload digest
+      - name: Image digest
         if: github.event_name != 'pull_request'
-        run: |
-          echo "${{ matrix.platform }} digest: ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
-
-  manifest:
-    needs: build
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Create and push manifest list
-        run: |
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-arm64
-
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:linux-arm64
-
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+        run: echo ${{ steps.meta.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,8 @@ COPY api ./api
 COPY rnudb_utils ./rnudb_utils
 
 # Create venv and install dependencies using uv
-# Force compilation from source for native extensions to ensure cross-arch compatibility
 RUN uv venv --python 3.11 .venv && \
-    uv sync --python .venv/bin/python --no-binary
+    uv sync --python .venv/bin/python
 
 # --------------------------------------------------
 # Stage 3: Final runtime (distroless, non-root)


### PR DESCRIPTION
## Summary
- Use matrix strategy where each native runner builds its platform
- ubuntu-latest builds linux/amd64 natively
- ubuntu-24.04-arm builds linux/arm64 natively
- Removes QEMU for ARM (not needed with native runner)

This fixes the "Exec format error" when ARM runner tried to build amd64.