### PR TITLE
fix: JWT_SECRET_KEY default mismatch and docker-compose.yml env vars

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -18,7 +18,7 @@ router = APIRouter()
 # Config from environment
 GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID", "")
 GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
-JWT_SECRET_KEY = os.environ.get("JWT_SECRET_KEY", "")
+JWT_SECRET_KEY = os.environ.get("JWT_SECRET_KEY", "dev-secret-key")
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "https://rnudb.rarediseasegenomics.org")
 ADMIN_GITHUB_LOGINS = [
     u.strip().lower()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,13 @@ services:
     image: ghcr.io/computational-rare-disease-genomics-whg/rnudb:latest
     ports:
       - "8000:8000"
+    environment:
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - ADMIN_GITHUB_LOGINS=${ADMIN_GITHUB_LOGINS}
+      - FRONTEND_URL=${FRONTEND_URL}
+      - NODE_ENV=production
     volumes:
       - ./data:/app/data
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production


### PR DESCRIPTION
## Summary
- Match JWT_SECRET_KEY default in auth.py with main.py (use "dev-secret-key" instead of empty string)
- Add explicit environment variables to docker-compose.yml to ensure they are passed to container

## Root Cause
The JWT token was being signed with one key (or empty string) but validated with a different default ("dev-secret-key" from main.py), causing all authentication attempts to fail with 401.

## Testing
After merging, rebuild the Docker image and redeploy to Oracle ARM server to verify login works.