### PR TITLE
fix: multi-arch manifest merge failure (v2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,8 @@ jobs:
 
       - name: Create and push multi-arch manifest
         run: |
-          AMD64_DIGEST="${{ needs.build.outputs.linux/amd64_digest }}"
-          ARM64_DIGEST="${{ needs.build.outputs.linux/arm64_digest }}"
+          AMD64_DIGEST="${{ needs.build.outputs['linux/amd64_digest'] }}"
+          ARM64_DIGEST="${{ needs.build.outputs['linux/arm64_digest'] }}"
 
           # Extract SHA256 from digests
           AMD64_SHA=$(echo "$AMD64_DIGEST" | grep -oP 'sha256:[a-f0-9]+' | head -1)


### PR DESCRIPTION
## Summary
- Added `id: build` to build-push-action so digest output is captured correctly
- Fixed output key references in manifest job using bracket notation: `outputs['linux/amd64_digest']`

This fixes the GHCR deployment issue where the Oracle ARM server showed "no matching manifest for linux/arm64/v8".