### PR TITLE
fix: use separate jobs for amd64/arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,11 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-amd64:
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -33,7 +26,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Set up QEMU
-        if: matrix.platform == 'linux/amd64'
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to Container Registry
@@ -62,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -71,10 +63,60 @@ jobs:
 
       - name: Output digest
         if: github.event_name != 'pull_request'
-        run: echo "${{ matrix.platform }}_digest=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
+        run: echo "amd64_digest=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
+
+  build-arm64:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output digest
+        if: github.event_name != 'pull_request'
+        run: echo "arm64_digest=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   manifest:
-    needs: build
+    needs: [build-amd64, build-arm64]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -107,8 +149,8 @@ jobs:
 
       - name: Create and push multi-arch manifest
         run: |
-          AMD64_DIGEST="${{ needs.build.outputs['linux/amd64_digest'] }}"
-          ARM64_DIGEST="${{ needs.build.outputs['linux/arm64_digest'] }}"
+          AMD64_DIGEST="${{ needs.build-amd64.outputs.amd64_digest }}"
+          ARM64_DIGEST="${{ needs.build-arm64.outputs.arm64_digest }}"
 
           # Extract SHA256 from digests
           AMD64_SHA=$(echo "$AMD64_DIGEST" | grep -oP 'sha256:[a-f0-9]+' | head -1)


### PR DESCRIPTION
## Summary
- Split matrix build job into two separate jobs: `build-amd64` and `build-arm64`
- Each job outputs its digest as `amd64_digest` and `arm64_digest` (clean keys)
- Manifest job now depends on both jobs and can access outputs properly

This fixes the GitHub Actions issue where matrix job outputs with slash keys (like `linux/amd64_digest`) weren't accessible in the dependent job. With separate jobs, each outputs its digest with a clean key that can be properly referenced.