### PR TITLE
fix: restore snake_case field names in import validation

### DIFF
--- a/src/hooks/useImportExport.test.ts
+++ b/src/hooks/useImportExport.test.ts
@@ -93,7 +93,7 @@ describe("useImportExport", () => {
         name: "Test",
         nucleotides: [{ id: 1, base: "A", x: 100, y: 100 }],
         base_pairs: [
-          { from: "not-a-number", to: 2 }, // invalid from
+          { from_pos: "not-a-number", to_pos: 2 }, // invalid from_pos
         ],
       });
 

--- a/src/hooks/useImportExport.ts
+++ b/src/hooks/useImportExport.ts
@@ -53,7 +53,7 @@ export const useImportExport = () => {
         !parsed.id ||
         !parsed.name ||
         !Array.isArray(parsed.nucleotides) ||
-        !Array.isArray(parsed.basePairs)
+        !Array.isArray(parsed.base_pairs)
       ) {
         throw new Error("Invalid RNA data structure");
       }
@@ -70,10 +70,10 @@ export const useImportExport = () => {
       }
 
       // Validate base pairs
-      for (const basePair of parsed.basePairs) {
+      for (const basePair of parsed.base_pairs) {
         if (
-          typeof basePair.from !== "number" ||
-          typeof basePair.to !== "number"
+          typeof basePair.from_pos !== "number" ||
+          typeof basePair.to_pos !== "number"
         ) {
           throw new Error("Invalid base pair structure");
         }


### PR DESCRIPTION
## Summary

- Revert `importFromJSON` validation to check for `base_pairs` (not `basePairs`) with `from_pos`/`to_pos` (not `from`/`to`)
- Update test to use correct field names

## Problem

The import function was checking for camelCase field names (`basePairs`, `from`, `to`) but the rest of the codebase uses snake_case (`base_pairs`, `from_pos`, `to_pos`):

- Backend validation: `api/services/validation.py:325`
- Frontend tests: `src/hooks/useImportExport.test.ts:23`
- Placeholder data: `src/data/placeholder.ts:54`
- Database exports

This caused JSON exports from the backend/database to fail import validation.

## Files Changed

- `src/hooks/useImportExport.ts` - validation checks
- `src/hooks/useImportExport.test.ts` - test case

## Testing

- [x] All vitest tests pass
- [x] Build succeeds
- [x] Pre-commit checks pass