### PR TITLE
Fix/rna editor drag position

### DIFF
--- a/src/components/Editor/FullscreenCanvas.tsx
+++ b/src/components/Editor/FullscreenCanvas.tsx
@@ -121,6 +121,10 @@ const FullscreenCanvas = forwardRef<HTMLDivElement, FullscreenCanvasProps>(
       x: number;
       y: number;
     } | null>(null);
+    const [featureInitialPosition, setFeatureInitialPosition] = useState<{
+      x: number;
+      y: number;
+    } | null>(null);
 
     const handleLabelModalClose = useCallback(() => {
       setShowLabelModal(false);
@@ -298,43 +302,50 @@ const FullscreenCanvas = forwardRef<HTMLDivElement, FullscreenCanvasProps>(
         e.stopPropagation();
         setDraggingFeature(featureId);
         setFeatureDragStart({ x: e.clientX, y: e.clientY });
+        const feature = rnaData.structural_features?.find(
+          (f) => f.id === featureId,
+        );
+        if (feature) {
+          setFeatureInitialPosition({ x: feature.label_x, y: feature.label_y });
+        }
       }
     };
 
     const handleFeatureLabelMouseMove = (e: React.MouseEvent) => {
-      if (draggingFeature && featureDragStart) {
+      if (draggingFeature && featureDragStart && featureInitialPosition) {
         e.preventDefault();
-        const screenDeltaX = e.clientX - featureDragStart.x;
-        const screenDeltaY = e.clientY - featureDragStart.y;
-
-        const logicalDeltaX = screenDeltaX / zoomLevel;
-        const logicalDeltaY = screenDeltaY / zoomLevel;
-
-        const feature = rnaData.structural_features?.find(
-          (f) => f.id === draggingFeature,
-        );
-        if (feature) {
-          const updatedFeature = {
-            ...feature,
-            label_x: feature.label_x + logicalDeltaX,
-            label_y: feature.label_y + logicalDeltaY,
-          };
+        const svg =
+          e.currentTarget.querySelector<SVGSVGElement>("svg[viewBox]");
+        if (svg) {
+          const pt = new DOMPoint(e.clientX, e.clientY);
+          const currentSvgPoint = pt.matrixTransform(
+            svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+          );
+          const pt2 = new DOMPoint(featureDragStart.x, featureDragStart.y);
+          const initialSvgPoint = pt2.matrixTransform(
+            svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+          );
+          const newX =
+            featureInitialPosition.x + (currentSvgPoint.x - initialSvgPoint.x);
+          const newY =
+            featureInitialPosition.y + (currentSvgPoint.y - initialSvgPoint.y);
 
           onUpdateRnaData({
             ...rnaData,
             structural_features: rnaData.structural_features?.map((f) =>
-              f.id === draggingFeature ? updatedFeature : f,
+              f.id === draggingFeature
+                ? { ...f, label_x: newX, label_y: newY }
+                : f,
             ),
           });
         }
-
-        setFeatureDragStart({ x: e.clientX, y: e.clientY });
       }
     };
 
     const handleFeatureLabelMouseUp = () => {
       setDraggingFeature(null);
       setFeatureDragStart(null);
+      setFeatureInitialPosition(null);
     };
 
     const handleAddLabel = (text: string, fontSize: number) => {

--- a/src/components/Editor/FullscreenCanvas.tsx
+++ b/src/components/Editor/FullscreenCanvas.tsx
@@ -107,6 +107,10 @@ const FullscreenCanvas = forwardRef<HTMLDivElement, FullscreenCanvasProps>(
       x: number;
       y: number;
     } | null>(null);
+    const [labelInitialPosition, setLabelInitialPosition] = useState<{
+      x: number;
+      y: number;
+    } | null>(null);
     const [pendingLabelPosition, setPendingLabelPosition] = useState<{
       x: number;
       y: number;
@@ -240,38 +244,46 @@ const FullscreenCanvas = forwardRef<HTMLDivElement, FullscreenCanvasProps>(
         onLabelClick(e, labelId);
         setDraggingLabel(labelId);
         setLabelDragStart({ x: e.clientX, y: e.clientY });
+        const label = rnaData.annotations?.find((a) => a.id === labelId);
+        if (label) {
+          setLabelInitialPosition({ x: label.x, y: label.y });
+        }
       }
     };
 
     const handleLabelMouseMove = (e: React.MouseEvent) => {
-      if (draggingLabel && labelDragStart) {
+      if (draggingLabel && labelDragStart && labelInitialPosition) {
         e.preventDefault();
-        // Calculate delta in screen coordinates
-        const screenDeltaX = e.clientX - labelDragStart.x;
-        const screenDeltaY = e.clientY - labelDragStart.y;
-
-        // Use the same simple approach as nucleotides
-        const logicalDeltaX = screenDeltaX / zoomLevel;
-        const logicalDeltaY = screenDeltaY / zoomLevel;
-
-        // Update immediately without throttling
-        onUpdateRnaData({
-          ...rnaData,
-          annotations:
-            rnaData.annotations?.map((a) =>
-              a.id === draggingLabel
-                ? { ...a, x: a.x + logicalDeltaX, y: a.y + logicalDeltaY }
-                : a,
-            ) || [],
-        });
-
-        setLabelDragStart({ x: e.clientX, y: e.clientY });
+        const svg =
+          e.currentTarget.querySelector<SVGSVGElement>("svg[viewBox]");
+        if (svg) {
+          const pt = new DOMPoint(e.clientX, e.clientY);
+          const currentSvgPoint = pt.matrixTransform(
+            svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+          );
+          const pt2 = new DOMPoint(labelDragStart.x, labelDragStart.y);
+          const initialSvgPoint = pt2.matrixTransform(
+            svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+          );
+          const newX =
+            labelInitialPosition.x + (currentSvgPoint.x - initialSvgPoint.x);
+          const newY =
+            labelInitialPosition.y + (currentSvgPoint.y - initialSvgPoint.y);
+          onUpdateRnaData({
+            ...rnaData,
+            annotations:
+              rnaData.annotations?.map((a) =>
+                a.id === draggingLabel ? { ...a, x: newX, y: newY } : a,
+              ) || [],
+          });
+        }
       }
     };
 
     const handleLabelMouseUp = () => {
       setDraggingLabel(null);
       setLabelDragStart(null);
+      setLabelInitialPosition(null);
       if (labelUpdateRef.current) {
         cancelAnimationFrame(labelUpdateRef.current);
         labelUpdateRef.current = null;

--- a/src/components/Editor/FullscreenCanvas.tsx
+++ b/src/components/Editor/FullscreenCanvas.tsx
@@ -829,12 +829,17 @@ const FullscreenCanvas = forwardRef<HTMLDivElement, FullscreenCanvasProps>(
           }}
           onClick={(e) => {
             if (mode === "label") {
-              const rect = e.currentTarget.getBoundingClientRect();
-              const x = (e.clientX - rect.left - panOffset.x) / zoomLevel;
-              const y = (e.clientY - rect.top - panOffset.y) / zoomLevel;
-              setPendingLabelPosition({ x, y });
-              setShowLabelModal(true);
-              onSetLabelModalOpen(true);
+              const svg =
+                e.currentTarget.querySelector<SVGSVGElement>("svg[viewBox]");
+              if (svg) {
+                const pt = new DOMPoint(e.clientX, e.clientY);
+                const svgPoint = pt.matrixTransform(
+                  svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+                );
+                setPendingLabelPosition({ x: svgPoint.x, y: svgPoint.y });
+                setShowLabelModal(true);
+                onSetLabelModalOpen(true);
+              }
             } else {
               onCanvasClick(e);
             }

--- a/src/hooks/useDragAndZoom.ts
+++ b/src/hooks/useDragAndZoom.ts
@@ -24,17 +24,16 @@ interface DragAndZoomProps {
 export const useDragAndZoom = ({
   canvasRef,
   mode,
-  zoomLevel,
-  panOffset,
+  zoomLevel: _zoomLevel,
+  panOffset: _panOffset,
   onUpdateNucleotidePosition,
-  findSnapPosition,
-  nucleotides,
-  rnaData,
+  findSnapPosition: _findSnapPosition,
+  nucleotides: _nucleotides,
+  rnaData: _rnaData,
 }: DragAndZoomProps) => {
   const [draggedNucleotide, setDraggedNucleotide] = useState<number | null>(
     null,
   );
-  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
   const [lastPanPoint, setLastPanPoint] = useState({ x: 0, y: 0 });
   const animationFrameRef = useRef<number | null>(null);
@@ -42,7 +41,6 @@ export const useDragAndZoom = ({
     null,
   );
 
-  // Use requestAnimationFrame to batch position updates
   useEffect(() => {
     const updatePosition = () => {
       if (pendingUpdateRef.current) {
@@ -77,12 +75,6 @@ export const useDragAndZoom = ({
       if (mode === "select") {
         e.preventDefault();
         setDraggedNucleotide(nucleotideId);
-
-        // Use the same approach as labels - just store the starting mouse position
-        setDragOffset({
-          x: e.clientX,
-          y: e.clientY,
-        });
       }
     },
     [mode],
@@ -101,35 +93,14 @@ export const useDragAndZoom = ({
           newPanPoint: { x: e.clientX, y: e.clientY },
         };
       } else if (draggedNucleotide && mode === "select") {
-        const nucleotide = nucleotides.find((n) => n.id === draggedNucleotide);
-        if (nucleotide) {
-          // With no transforms, just use the mouse delta directly
-          const deltaX = e.clientX - dragOffset.x;
-          const deltaY = e.clientY - dragOffset.y;
-
-          // Convert screen pixels to SVG units (account for both viewBox and CSS transform)
-          const rect = canvasRef.current?.getBoundingClientRect();
-          if (rect) {
-            // Simple approach: just use the zoomLevel since we know it works
-            const logicalDeltaX = deltaX / zoomLevel;
-            const logicalDeltaY = deltaY / zoomLevel;
-
-            // Update nucleotide position by adding the delta
-            const newX = nucleotide.x + logicalDeltaX;
-            const newY = nucleotide.y + logicalDeltaY;
-
-            // Remove debug logging
-            // console.log('Drag:', { ... });
-
-            // Update nucleotide position
-            onUpdateNucleotidePosition(draggedNucleotide, newX, newY);
-
-            // Update the drag start position
-            setDragOffset({
-              x: e.clientX,
-              y: e.clientY,
-            });
-          }
+        const svg =
+          canvasRef.current?.querySelector<SVGSVGElement>("svg[viewBox]");
+        if (svg) {
+          const pt = new DOMPoint(e.clientX, e.clientY);
+          const svgPoint = pt.matrixTransform(
+            svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+          );
+          onUpdateNucleotidePosition(draggedNucleotide, svgPoint.x, svgPoint.y);
         }
       }
 
@@ -142,13 +113,7 @@ export const useDragAndZoom = ({
       lastPanPoint,
       mode,
       canvasRef,
-      dragOffset,
-      panOffset,
-      zoomLevel,
-      findSnapPosition,
       onUpdateNucleotidePosition,
-      nucleotides,
-      rnaData,
     ],
   );
 
@@ -173,7 +138,6 @@ export const useDragAndZoom = ({
 
   return {
     draggedNucleotide,
-    dragOffset,
     isPanning,
     lastPanPoint,
     handleNucleotideMouseDown,

--- a/src/hooks/useDragAndZoom.ts
+++ b/src/hooks/useDragAndZoom.ts
@@ -106,7 +106,7 @@ export const useDragAndZoom = ({
 
       return null;
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
     [
       isPanning,
       draggedNucleotide,

--- a/src/hooks/useDragAndZoom.ts
+++ b/src/hooks/useDragAndZoom.ts
@@ -106,7 +106,7 @@ export const useDragAndZoom = ({
 
       return null;
     },
-     
+
     [
       isPanning,
       draggedNucleotide,

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -202,10 +202,15 @@ const Editor: React.FC = () => {
   const handleCanvasClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (mode === "add") {
-        const rect = e.currentTarget.getBoundingClientRect();
-        const x = (e.clientX - rect.left - panOffset.x) / zoomLevel;
-        const y = (e.clientY - rect.top - panOffset.y) / zoomLevel;
-        addNucleotide(x, y);
+        const svg =
+          canvasRef.current?.querySelector<SVGSVGElement>("svg[viewBox]");
+        if (svg) {
+          const pt = new DOMPoint(e.clientX, e.clientY);
+          const svgPoint = pt.matrixTransform(
+            svg.getScreenCTM()?.inverse() ?? new DOMMatrix(),
+          );
+          addNucleotide(svgPoint.x, svgPoint.y);
+        }
         setMode("select");
       } else if (mode === "pair") {
         setSelectedNucleotides([]);
@@ -215,14 +220,7 @@ const Editor: React.FC = () => {
         setCurrentLabel(null);
       }
     },
-    [
-      mode,
-      addNucleotide,
-      panOffset,
-      zoomLevel,
-      setSelectedNucleotides,
-      setCurrentNucleotide,
-    ],
+    [mode, addNucleotide, setSelectedNucleotides, setCurrentNucleotide],
   );
 
   const handleMouseMoveWithPan = useCallback(


### PR DESCRIPTION
This pull request significantly improves the accuracy and consistency of coordinate calculations for dragging and placing elements (nucleotides, labels, and features) on the RNA editor canvas. The main change is a shift from using manual math on screen coordinates to using SVG's coordinate transformation, which ensures correct placement regardless of zoom or pan. The changes also add state to track initial positions for smoother drag interactions.

**Coordinate transformation improvements:**

* All mouse interactions that set or update positions for nucleotides, labels, and features now use SVG's `getScreenCTM().inverse()` to convert screen coordinates to logical SVG coordinates, replacing previous manual calculations. This ensures precise and consistent placement regardless of zoom or pan. [[1]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bR251-R290) [[2]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bR305-R348) [[3]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bL832-R865) [[4]](diffhunk://#diff-8f46b62aa9dfecfeda8a52caa0cc2c41c8e16619ba23190fd611bfa53f2c2b07L104-R103) [[5]](diffhunk://#diff-b99ee5c128b8dac5b4c791d835f1c5983a0dd970de5fd94c791908107370c4c4L205-R213)

**Drag interaction enhancements:**

* Added state to track the initial position of labels and features (`labelInitialPosition`, `featureInitialPosition`), allowing drag operations to correctly calculate deltas in SVG space. These are reset after drag ends. [[1]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bR110-R113) [[2]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bR124-R127) [[3]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bR251-R290) [[4]](diffhunk://#diff-21a6fc73f416d31dc1f54b831cf769c63d32a84cfb35ca8bb7dfec188308b60bR305-R348)

**Code cleanup and refactoring:**

* Removed unused or redundant state and parameters (like `dragOffset`, and some destructured props) from `useDragAndZoom`, simplifying the drag logic. [[1]](diffhunk://#diff-8f46b62aa9dfecfeda8a52caa0cc2c41c8e16619ba23190fd611bfa53f2c2b07L27-L45) [[2]](diffhunk://#diff-8f46b62aa9dfecfeda8a52caa0cc2c41c8e16619ba23190fd611bfa53f2c2b07L80-L85) [[3]](diffhunk://#diff-8f46b62aa9dfecfeda8a52caa0cc2c41c8e16619ba23190fd611bfa53f2c2b07L145-L151) [[4]](diffhunk://#diff-8f46b62aa9dfecfeda8a52caa0cc2c41c8e16619ba23190fd611bfa53f2c2b07L176)
* Cleaned up dependency arrays in callbacks to avoid unnecessary dependencies.