### PR TITLE
Order variant-classifications by rowid for deterministic results

### DIFF
--- a/api/routers/variants.py
+++ b/api/routers/variants.py
@@ -172,7 +172,11 @@ async def delete_variant(
 )
 async def get_variant_classifications(db: Session = Depends(get_db)):
     """Get all variant classifications linking variants to literature"""
-    classifications = db.execute(select(VariantClassification)).scalars().all()
+    classifications = (
+        db.execute(select(VariantClassification).order_by(text("rowid")))
+        .scalars()
+        .all()
+    )
     return [VariantClassificationPublic.model_validate(c) for c in classifications]
 
 
@@ -186,9 +190,9 @@ async def get_variant_classifications_for_variant(
     """Get all classifications for a specific variant"""
     classifications = (
         db.execute(
-            select(VariantClassification).where(
-                VariantClassification.variant_id == variant_id
-            )
+            select(VariantClassification)
+            .where(VariantClassification.variant_id == variant_id)
+            .order_by(text("rowid"))
         )
         .scalars()
         .all()
@@ -199,7 +203,11 @@ async def get_variant_classifications_for_variant(
 @router.get("/literature-counts", response_model=list[VariantClassificationPublic])
 async def get_literature_counts(db: Session = Depends(get_db)):
     """Get all variant classifications (legacy, use /variant-classifications)"""
-    classifications = db.execute(select(VariantClassification)).scalars().all()
+    classifications = (
+        db.execute(select(VariantClassification).order_by(text("rowid")))
+        .scalars()
+        .all()
+    )
     return [VariantClassificationPublic.model_validate(c) for c in classifications]
 
 
@@ -374,6 +382,7 @@ async def get_gene_variant_classifications(gene_id: str, db: Session = Depends(g
             select(VariantClassification)
             .join(Variant, Variant.id == VariantClassification.variant_id)
             .where(Variant.geneId == gene_id)
+            .order_by(text("rowid"))
         )
         .scalars()
         .all()


### PR DESCRIPTION
## Summary
- Add `ORDER BY rowid ASC` to all variant-classifications queries in `api/routers/variants.py`
- This ensures consistent ordering when listing papers for a variant

## Changes
- `api/routers/variants.py`: Added `order_by(text("rowid"))` to 4 endpoints:
  - `GET /variant-classifications`
  - `GET /variant-classifications/{variant_id}`
  - `GET /literature-counts`
  - `GET /genes/{gene_id}/variant-classifications`

## Workflow
2. Delete and reimport gene data on deployment