### PR TITLE
Cascade delete variant_classifications when deleting a gene

### DIFF
--- a/api/routers/genes.py
+++ b/api/routers/genes.py
@@ -322,6 +322,13 @@ async def delete_gene(gene_id: str, request: Request, db: Session = Depends(get_
 
     # Delete associated data
     db.execute(
+        text(
+            "DELETE FROM variant_classifications "
+            "WHERE variant_id IN (SELECT id FROM variants WHERE geneId = :gene_id)"
+        ),
+        {"gene_id": gene_id},
+    )
+    db.execute(
         text("DELETE FROM variants WHERE geneId = :gene_id"), {"gene_id": gene_id}
     )
     db.execute(


### PR DESCRIPTION
## Summary
- Fixes bug where variant_classifications were orphaned when a gene was deleted
- Now when deleting a gene via `DELETE /api/genes/{gene_id}`, variant_classifications are also deleted (cascade)
- This ensures proper cleanup when reimporting data

## Changes
- `api/routers/genes.py`: Added DELETE statement for variant_classifications before deleting variants

```python
db.execute(
    text(
        "DELETE FROM variant_classifications "
        "WHERE variant_id IN (SELECT id FROM variants WHERE geneId = :gene_id)"
    ),
    {"gene_id": gene_id},
)
```

## Why This Matters
When deleting a gene and reimporting, SQLite rowids were being recycled from deleted space rather than assigned fresh. Now with proper cascade delete, the variant_classifications table is fully cleaned before reimport.