### PR TITLE
fix: Likely Pathogenic variants invisible in RNAViewer (#165)

### DIFF
--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -183,6 +183,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
         const maxSignificance = filteredVariants.reduce((max, v) => {
           const significanceOrder: Record<string, number> = {
             Pathogenic: 4,
+            "Likely Pathogenic": 4,
             VUS: 2,
             "Likely Benign": 1,
             Benign: 0,
@@ -196,6 +197,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
 
         const valueMap: Record<string, number> = {
           Pathogenic: 1,
+          "Likely Pathogenic": 1,
           VUS: 0.25,
           "Likely Benign": 0.125,
           Benign: 0,


### PR DESCRIPTION
## Summary

Fixes #165 — Likely Pathogenic variants are invisible in the RNAViewer after the merge in c05168c.

## Root Cause

When merging Pathogenic and Likely Pathogenic into a single group, the "Likely Pathogenic" entries were **deleted** from two internal lookup tables instead of being mapped to the same values as "Pathogenic":

| Table | Before commit | After commit (bug) | Fix |
|---|---|---|---|
| `significanceOrder` | "Likely Pathogenic": 3 | deleted → -1 (below Benign) | "Likely Pathogenic": 4 |
| `valueMap` | "Likely Pathogenic": 0.75 | deleted → 0 (invisible) | "Likely Pathogenic": 1 |

## How LP became invisible

1. LP passes the filter ✅
2. `valueMap["Likely Pathogenic"]` → `undefined` → `?? 0` → value `0`
3. `getOverlayColor`: `if (!value) return NEUTRAL_BACKGROUND` → **invisible** ❌

## Why Pathogenic still worked

Positions with both Pathogenic + LP: Pathogenic's `order=4` beat LP's `order=-1` in the reduce → still red ✅

Positions with **only** LP: LP gets `order=-1`, `value=0` → invisible ❌

## What was changed

Two lines in `src/components/RNAViewer/RNAViewer.tsx`:
- `significanceOrder`: added `"Likely Pathogenic": 4` (same as Pathogenic)
- `valueMap`: added `"Likely Pathogenic": 1` (same as Pathogenic)

The existing tiebreaker (`order === maxOrder && v.clinical_significance === "Pathogenic"`) already ensures Pathogenic wins when both exist at the same position.