### PR TITLE
fix: remove broken depletion group track, replace function score bars with jittered dot plot

### DIFF
--- a/src/components/GenomeBrowser/FunctionScoreTrack.tsx
+++ b/src/components/GenomeBrowser/FunctionScoreTrack.tsx
@@ -1,0 +1,166 @@
+import { Track } from "@gnomad/region-viewer";
+import React from "react";
+import { COLORBLIND_FRIENDLY_PALETTE } from "../../lib/colors";
+
+interface FunctionScoreTrackProps {
+  variants: {
+    id: string;
+    function_score?: number | null;
+    nucleotidePosition?: number | null;
+    position?: number;
+    ref?: string;
+    alt?: string;
+    hgvs?: string;
+  }[];
+  regions: { start: number; stop: number }[];
+  geneStart: number;
+  geneStrand?: string;
+  geneEnd?: number;
+}
+
+const FunctionScoreTrack: React.FC<FunctionScoreTrackProps> = ({
+  variants,
+  regions,
+  geneStart,
+  geneStrand,
+  geneEnd,
+}) => {
+  const height = 80;
+  const padding = 15;
+  const currentRegion = regions[0];
+  const jitterRange = 6;
+
+  const getNucleotidePos = (v: {
+    nucleotidePosition?: number | null;
+    position?: number;
+  }): number | null => {
+    if (v.nucleotidePosition != null) return v.nucleotidePosition;
+    if (v.position != null && geneStrand && geneEnd) {
+      return geneStrand === "-" ? geneEnd - v.position + 1 : v.position - geneStart + 1;
+    }
+    return null;
+  };
+
+  const points = variants
+    .filter(
+      (v) =>
+        v.function_score !== undefined &&
+        v.function_score !== null &&
+        getNucleotidePos(v) !== null,
+    )
+    .map((v) => ({
+      nucleotidePos: getNucleotidePos(v)!,
+      genomicPos: geneStart + getNucleotidePos(v)! - 1,
+      value: v.function_score!,
+      variantId: v.id,
+      hgvs: v.hgvs,
+      ref: v.ref,
+      alt: v.alt,
+    }))
+    .filter(
+      (p) => p.genomicPos >= currentRegion.start && p.genomicPos <= currentRegion.stop,
+    );
+
+  const positions = [...new Set(points.map((p) => p.nucleotidePos))].sort(
+    (a, b) => a - b,
+  );
+
+  const values = points.map((p) => p.value);
+  const minValue = values.length > 0 ? Math.min(...values) : 0;
+  const maxValue = values.length > 0 ? Math.max(...values) : 0;
+  const valueRange = maxValue - minValue || 1;
+
+  const scaleY = (value: number) => {
+    const normalized = (maxValue - value) / valueRange;
+    return padding + normalized * (height - 2 * padding);
+  };
+
+  const getColor = (score: number) => {
+    if (score > 0) return COLORBLIND_FRIENDLY_PALETTE.DEPLETION.NORMAL;
+    if (score < -1) return COLORBLIND_FRIENDLY_PALETTE.DEPLETION.STRONG;
+    return COLORBLIND_FRIENDLY_PALETTE.DEPLETION.MODERATE;
+  };
+
+  const groupKey = (p: (typeof points)[0]) => `${p.genomicPos}-${p.nucleotidePos}`;
+
+  return (
+    <Track title="Function Score">
+      {({ scalePosition, width }) => (
+        <svg height={height} width={width}>
+          <rect
+            x={0}
+            y={0}
+            width={width}
+            height={height}
+            fill="white"
+            stroke="#e5e7eb"
+          />
+
+          {values.length > 0 && (
+            <>
+              <text
+                x={5}
+                y={padding + 4}
+                fontSize="10"
+                fill="#6B7280"
+                textAnchor="start"
+              >
+                {maxValue.toFixed(2)}
+              </text>
+              <text
+                x={5}
+                y={height - padding + 4}
+                fontSize="10"
+                fill="#6B7280"
+                textAnchor="start"
+              >
+                {minValue.toFixed(2)}
+              </text>
+            </>
+          )}
+
+          {minValue < 0 && maxValue > 0 && (
+            <line
+              x1={0}
+              y1={scaleY(0)}
+              x2={width}
+              y2={scaleY(0)}
+              stroke="#d1d5db"
+              strokeWidth={1}
+              strokeDasharray="2,2"
+            />
+          )}
+
+          {positions.map((pos) => {
+            const posPoints = points.filter((p) => p.nucleotidePos === pos);
+            const n = posPoints.length;
+            const xCenter = scalePosition(posPoints[0].genomicPos);
+
+            return posPoints.map((p, i) => {
+              const offset = n === 1 ? 0 : ((i / (n - 1)) * 2 - 1) * jitterRange;
+              return (
+                <g key={groupKey(p)}>
+                  <circle
+                    cx={xCenter + offset}
+                    cy={scaleY(p.value)}
+                    r={4}
+                    fill={getColor(p.value)}
+                    stroke="white"
+                    strokeWidth={1}
+                  />
+                  <title>
+                    {`Position ${p.nucleotidePos}: Function Score = ${p.value.toFixed(3)}`}
+                    {p.hgvs ? `\n${p.hgvs}` : ""}
+                    {p.ref && p.alt ? `\n${p.ref}>${p.alt}` : ""}
+                  </title>
+                </g>
+              );
+            });
+          })}
+        </svg>
+      )}
+    </Track>
+  );
+};
+
+export default FunctionScoreTrack;

--- a/src/components/GenomeBrowser/GenericTrack.tsx
+++ b/src/components/GenomeBrowser/GenericTrack.tsx
@@ -12,7 +12,7 @@ interface GenericTrackProps {
     };
   };
   regions: { start: number; stop: number }[];
-  displayType?: "bars" | "line";
+  displayType?: "bars" | "line" | "points";
   geneStart: number;
 }
 
@@ -139,6 +139,23 @@ const GenericTrack: React.FC<GenericTrackProps> = ({
                   </g>
                 ))}
               </>
+            ) : displayType === "points" ? (
+              /* Point/Dot Plot */
+              dataPoints.map((point) => (
+                <g key={`track-item-${point.genomicPos}`}>
+                  <circle
+                    cx={scalePosition(point.genomicPos)}
+                    cy={scaleY(point.value)}
+                    r={4}
+                    fill={point.color || "#374151"}
+                    stroke="white"
+                    strokeWidth={1}
+                  />
+                  <title>
+                    {`Nucleotide ${point.nucleotide}: ${point.label || point.value}`}
+                  </title>
+                </g>
+              ))
             ) : (
               /* Bar Graph */
               dataPoints.map((point) => {

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -4,7 +4,7 @@ import domtoimage from "dom-to-image-more";
 import { ZoomIn, ZoomOut, RotateCcw, Download, FileImage } from "lucide-react";
 import React, { useState, useRef, useEffect } from "react";
 import DomainsTrack from "./DomainsTrack";
-import GenericTrack from "./GenericTrack";
+import FunctionScoreTrack from "./FunctionScoreTrack";
 import SequenceTrack from "./SequenceTrack";
 import SnRNAVariantTrack from "./SnRNAVariantTrack";
 import { Button } from "@/components/ui/button";
@@ -16,7 +16,6 @@ interface GenomeBrowserProps {
   gnomadVariants: any[];
   aouVariants: any[];
   structuralFeatures: any[];
-  functionScoreTrackData: any;
   geneData: {
     id: string;
     name: string;
@@ -34,7 +33,6 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
   gnomadVariants,
   aouVariants,
   structuralFeatures,
-  functionScoreTrackData,
   geneData,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -227,13 +225,12 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
               regions={regions}
               geneStart={geneData.start}
             />
-            <GenericTrack
-              title="Function Score"
-              height={80}
-              data={functionScoreTrackData}
+            <FunctionScoreTrack
+              variants={variants}
               regions={regions}
-              displayType="points"
               geneStart={geneData.start}
+              geneStrand={geneData.strand}
+              geneEnd={geneData.end}
             />
             <SnRNAVariantTrack
               variants={variants}

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -17,7 +17,6 @@ interface GenomeBrowserProps {
   aouVariants: any[];
   structuralFeatures: any[];
   functionScoreTrackData: any;
-  depletionGroupTrackData: any;
   geneData: {
     id: string;
     name: string;
@@ -36,7 +35,6 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
   aouVariants,
   structuralFeatures,
   functionScoreTrackData,
-  depletionGroupTrackData,
   geneData,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -234,15 +232,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
               height={80}
               data={functionScoreTrackData}
               regions={regions}
-              displayType="bars"
-              geneStart={geneData.start}
-            />
-            <GenericTrack
-              title="Depletion Group"
-              height={30}
-              data={depletionGroupTrackData}
-              regions={regions}
-              displayType="bars"
+              displayType="points"
               geneStart={geneData.start}
             />
             <SnRNAVariantTrack

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -34,7 +34,6 @@ interface MainContentProps {
   overlayMode: "none" | "clinvar" | "gnomad" | "depletion_group";
   getCurrentOverlayData: () => OverlayData;
   cycleOverlayMode: () => void;
-  functionScoreTrackData?: OverlayData;
 }
 
 const MainContent: React.FC<MainContentProps> = ({
@@ -49,7 +48,6 @@ const MainContent: React.FC<MainContentProps> = ({
   overlayMode,
   getCurrentOverlayData,
   cycleOverlayMode,
-  functionScoreTrackData,
 }) => {
   const [hoveredNucleotide, setHoveredNucleotide] = useState<Nucleotide | null>(null);
   const [selectedNucleotide, setSelectedNucleotide] = useState<Nucleotide | null>(null);
@@ -221,7 +219,6 @@ const MainContent: React.FC<MainContentProps> = ({
                 gnomadVariants={gnomadVariants}
                 aouVariants={aouVariants}
                 structuralFeatures={rnaStructureData?.structural_features || []}
-                functionScoreTrackData={functionScoreTrackData}
                 geneData={{
                   id: currentData.id,
                   name: currentData.name,

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -35,7 +35,6 @@ interface MainContentProps {
   getCurrentOverlayData: () => OverlayData;
   cycleOverlayMode: () => void;
   functionScoreTrackData?: OverlayData;
-  depletionGroupTrackData: OverlayData;
 }
 
 const MainContent: React.FC<MainContentProps> = ({
@@ -51,7 +50,6 @@ const MainContent: React.FC<MainContentProps> = ({
   getCurrentOverlayData,
   cycleOverlayMode,
   functionScoreTrackData,
-  depletionGroupTrackData,
 }) => {
   const [hoveredNucleotide, setHoveredNucleotide] = useState<Nucleotide | null>(null);
   const [selectedNucleotide, setSelectedNucleotide] = useState<Nucleotide | null>(null);
@@ -224,7 +222,6 @@ const MainContent: React.FC<MainContentProps> = ({
                 aouVariants={aouVariants}
                 structuralFeatures={rnaStructureData?.structural_features || []}
                 functionScoreTrackData={functionScoreTrackData}
-                depletionGroupTrackData={depletionGroupTrackData}
                 geneData={{
                   id: currentData.id,
                   name: currentData.name,

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -33,7 +33,6 @@ const Gene: React.FC = () => {
   const [overlayMode, setOverlayMode] = useState<
     "none" | "clinvar" | "gnomad" | "depletion_group"
   >("clinvar");
-  const [functionScoreTrackData, setFunctionScoreTrackData] = useState({});
   const [depletionGroupTrackData, setDepletionGroupTrackData] = useState({});
   const [clinvarOverlayData, setClinvarOverlayData] = useState({});
   const [gnomadOverlayData, setGnomadOverlayData] = useState({});
@@ -169,31 +168,6 @@ const Gene: React.FC = () => {
       );
     };
 
-    const createFunctionScoreTrackData = (variants: Variant[]) => {
-      return Object.fromEntries(
-        variants
-          .filter(
-            (v) =>
-              v.function_score !== undefined &&
-              v.function_score !== null &&
-              v.nucleotidePosition !== undefined,
-          )
-          .map((v) => [
-            v.nucleotidePosition!,
-            {
-              value: v.function_score!,
-              label: `Function Score: ${v.function_score!.toFixed(3)}`,
-              color:
-                v.function_score! > 0
-                  ? COLORBLIND_FRIENDLY_PALETTE.DEPLETION.NORMAL
-                  : v.function_score! < -1
-                    ? COLORBLIND_FRIENDLY_PALETTE.DEPLETION.STRONG
-                    : COLORBLIND_FRIENDLY_PALETTE.DEPLETION.MODERATE,
-            },
-          ]),
-      );
-    };
-
     const createGnomadOverlayData = (variants: Variant[], geneData: SnRNAGene) => {
       return Object.fromEntries(
         variants
@@ -224,7 +198,6 @@ const Gene: React.FC = () => {
       );
     };
 
-    const funcScoreData = createFunctionScoreTrackData(variantData);
     const depletionData = createDepletionGroupTrackData(variantData);
     const clinvarData = currentData
       ? createClinvarOverlayData(variantData, currentData)
@@ -232,7 +205,6 @@ const Gene: React.FC = () => {
     const gnomadData = currentData
       ? createGnomadOverlayData(variantData, currentData)
       : {};
-    setFunctionScoreTrackData(funcScoreData);
     setDepletionGroupTrackData(depletionData);
     setClinvarOverlayData(clinvarData);
     setGnomadOverlayData(gnomadData);
@@ -349,7 +321,6 @@ const Gene: React.FC = () => {
             overlayMode={overlayMode}
             getCurrentOverlayData={getCurrentOverlayData}
             cycleOverlayMode={cycleOverlayMode}
-            functionScoreTrackData={functionScoreTrackData}
             aouVariants={aouVariants}
           />
         </div>

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -350,7 +350,6 @@ const Gene: React.FC = () => {
             getCurrentOverlayData={getCurrentOverlayData}
             cycleOverlayMode={cycleOverlayMode}
             functionScoreTrackData={functionScoreTrackData}
-            depletionGroupTrackData={depletionGroupTrackData}
             aouVariants={aouVariants}
           />
         </div>


### PR DESCRIPTION
## Summary

### 1. Remove Depletion Group track from genome browser

The track had zero-height bars due to `height=30` with `padding=15` leaving no drawable space (`height - 2*padding = 0`), making it appear visually blank. The RNA viewer's depletion group color overlay is unaffected.

### 2. Replace Function Score bars with jittered dot plot

The old `GenericTrack`-based function score track used `Object.fromEntries()` keyed by `nucleotidePosition`, which **silently dropped all but one variant** at positions with multiple variants. Sample data shows up to 9 variants per position.

**New `FunctionScoreTrack` component:**
- Takes the raw `variants` array directly
- Groups by `nucleotidePosition` — when N variants share a position, dots are spread horizontally with uniform spacing (`±6px` jitter range)
- Color-coded: green (score > 0), amber (score -1 to 0), red (score < -1)
- Tooltip shows exact score, HGVS notation, and ref/alt alleles
- Y-axis range auto-scales to data

## Changes

| File | Change |
|------|--------|
| `src/components/GenomeBrowser/FunctionScoreTrack.tsx` | **New** — jittered dot plot component taking variants directly |
| `src/components/GenomeBrowser/GenomeBrowser.tsx` | Swapped GenericTrack for FunctionScoreTrack; removed `functionScoreTrackData` prop |
| `src/components/MainContent.tsx` | Removed `functionScoreTrackData` prop |
| `src/pages/Gene.tsx` | Removed `functionScoreTrackData` state and `createFunctionScoreTrackData` |