### PR TITLE
feat: change VUS colour from amber to blue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -136,7 +136,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
     } else if (lower.includes("benign")) {
       return "bg-green-50 text-green-700 border-green-200";
     } else if (lower === "vus" || lower.includes("uncertain")) {
-      return "bg-amber-50 text-amber-700 border-amber-200";
+      return "bg-blue-50 text-blue-700 border-blue-200";
     }
     return "bg-gray-50 text-gray-700 border-gray-200";
   };

--- a/src/components/VariantsSection.tsx
+++ b/src/components/VariantsSection.tsx
@@ -53,7 +53,7 @@ const VariantsSection: React.FC<VariantsSectionProps> = ({
       Pathogenic: "bg-red-100 text-red-800 border-red-200",
       "Likely Pathogenic": "bg-red-100 text-red-700 border-red-200",
       "Likely Benign": "bg-emerald-100 text-emerald-700 border-emerald-200",
-      VUS: "bg-amber-100 text-amber-800 border-amber-200",
+      VUS: "bg-blue-100 text-blue-800 border-blue-200",
       B: "bg-emerald-100 text-emerald-800 border-emerald-200",
       LB: "bg-emerald-100 text-emerald-700 border-emerald-200",
       P: "bg-red-100 text-red-800 border-red-200",

--- a/src/lib/colors.test.ts
+++ b/src/lib/colors.test.ts
@@ -18,7 +18,7 @@ describe("COLORBLIND_FRIENDLY_PALETTE", () => {
   it("has valid CLINVAR colors", () => {
     expect(COLORBLIND_FRIENDLY_PALETTE.CLINVAR.PATHOGENIC).toBe("#DC2626");
     expect(COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_PATHOGENIC).toBe("#EA580C");
-    expect(COLORBLIND_FRIENDLY_PALETTE.CLINVAR.VUS).toBe("#F59E0B");
+    expect(COLORBLIND_FRIENDLY_PALETTE.CLINVAR.VUS).toBe("#2563EB");
     expect(COLORBLIND_FRIENDLY_PALETTE.CLINVAR.BENIGN).toBe("#059669");
     expect(COLORBLIND_FRIENDLY_PALETTE.CLINVAR.LIKELY_BENIGN).toBe("#047857");
   });
@@ -113,11 +113,11 @@ describe("getClinvarColor", () => {
   });
 
   it("returns VUS for uncertain significance", () => {
-    expect(getClinvarColor("VUS")).toBe("#F59E0B");
+    expect(getClinvarColor("VUS")).toBe("#2563EB");
   });
 
   it("returns VUS for unrecognized strings", () => {
-    expect(getClinvarColor("random")).toBe("#F59E0B");
+    expect(getClinvarColor("random")).toBe("#2563EB");
   });
 });
 

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -11,7 +11,7 @@ export const COLORBLIND_FRIENDLY_PALETTE = {
   CLINVAR: {
     PATHOGENIC: "#DC2626", // Dark red - most severe
     LIKELY_PATHOGENIC: "#EA580C", // Orange-red - moderately severe
-    VUS: "#F59E0B", // Amber - uncertain significance
+    VUS: "#2563EB", // Blue - uncertain significance
     BENIGN: "#059669", // Emerald green - safe
     LIKELY_BENIGN: "#047857", // Darker green
   },
@@ -54,7 +54,7 @@ export const COLORBLIND_FRIENDLY_PALETTE = {
     GNOMAD: "#2563EB", // Blue
     CLINVAR_PATHOGENIC: "#DC2626", // Red
     CLINVAR_BENIGN: "#059669", // Green
-    CLINVAR_VUS: "#F59E0B", // Amber
+    CLINVAR_VUS: "#2563EB", // Blue
   },
 
   // Function Score colors (diverging scale - colorblind safe)

--- a/src/pages/Curate.tsx
+++ b/src/pages/Curate.tsx
@@ -503,7 +503,7 @@ const Curate: React.FC = () => {
       case "Likely Pathogenic":
         return "bg-red-50 text-red-700 border-red-200";
       case "VUS":
-        return "bg-amber-50 text-amber-700 border-amber-200";
+        return "bg-blue-50 text-blue-700 border-blue-200";
       case "Likely Benign":
         return "bg-emerald-50 text-emerald-700 border-emerald-200";
       case "Benign":


### PR DESCRIPTION
Changes the VUS (Variant of Uncertain Significance) colour from amber (#F59E0B) to blue (#2563EB).

### Files changed
- **`src/lib/colors.ts`**: Updated  and  hex values
- **`src/lib/colors.test.ts`**: Updated test assertions to match new colour
- **`src/components/VariantsSection.tsx`**: Updated VUS badge Tailwind classes from amber to blue
- **`src/pages/Curate.tsx`**: Updated VUS badge Tailwind classes from amber to blue
- **`src/components/InfoPanel.tsx`**: Updated VUS significance colour from amber to blue
- **`.pre-commit-config.yaml`**: Pinned default Python to 3.11 to fix broken pre-commit on Python 3.14

### Verification
- 29/29 frontend unit tests pass (vitest)
- 122/122 backend tests pass (pytest)
- Production build succeeds (npm run build)
- All pre-commit hooks pass