### PR TITLE
feat: show patient observation counts (het/hom) in variant displays

### DIFF
--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -152,9 +152,11 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
     return counts
       .map((count) => {
         const literature = paperData.find((p) => p.id === count.literature_id);
-        return literature ? { ...literature, count: count.counts } : null;
+        return literature
+          ? { ...literature, count: count.counts, zygosity: count.zygosity }
+          : null;
       })
-      .filter((lit): lit is Literature & { count: number } => lit !== null);
+      .filter((lit): lit is NonNullable<typeof lit> => lit !== null);
   };
 
   return (
@@ -460,14 +462,23 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
                                           <span className="text-slate-600 truncate">
                                             {lit.authors} ({lit.year})
                                           </span>
-                                          <a
-                                            href={`https://doi.org/${lit.doi}`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="text-slate-400 hover:text-slate-600 shrink-0"
-                                          >
-                                            <ExternalLink className="h-3 w-3" />
-                                          </a>
+                                          <div className="flex items-center gap-2 shrink-0">
+                                            <span className="text-slate-400">
+                                              {lit.zygosity === "Heterozygous"
+                                                ? `${lit.count} het`
+                                                : lit.zygosity === "Homozygous"
+                                                  ? `${lit.count} hom`
+                                                  : `${lit.count}`}
+                                            </span>
+                                            <a
+                                              href={`https://doi.org/${lit.doi}`}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="text-slate-400 hover:text-slate-600"
+                                            >
+                                              <ExternalLink className="h-3 w-3" />
+                                            </a>
+                                          </div>
                                         </div>
                                       ))}
                                     </div>

--- a/src/components/VariantLiteratureCard.tsx
+++ b/src/components/VariantLiteratureCard.tsx
@@ -92,9 +92,22 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
     return counts
       .map((count) => {
         const paper = paperData.find((p) => p.id === count.literature_id);
-        return paper ? { ...paper, count: count.counts } : null;
+        return paper
+          ? { ...paper, count: count.counts, zygosity: count.zygosity }
+          : null;
       })
       .filter(Boolean);
+  };
+
+  const getVariantPatientStats = (variantId: string) => {
+    const counts = literatureCounts.filter((lc) => lc.variant_id === variantId);
+    let het = 0;
+    let hom = 0;
+    for (const c of counts) {
+      if (c.zygosity === "Heterozygous") het += c.counts ?? 0;
+      else if (c.zygosity === "Homozygous") hom += c.counts ?? 0;
+    }
+    return { het, hom, total: het + hom };
   };
 
   const getLinkedVariants = (variantId: string): Variant[] => {
@@ -541,7 +554,7 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
                         onClick={() => handleSort("papers")}
                         className="hover:text-slate-600"
                       >
-                        Papers{" "}
+                        Patients{" "}
                         {sortField === "papers"
                           ? sortDirection === "asc"
                             ? "↑"
@@ -628,7 +641,14 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
                           <td
                             className={`py-3 px-2 ${variantLit.length > 0 ? "text-blue-600 font-medium" : "text-slate-400"}`}
                           >
-                            {variantLit.length}
+                            {(() => {
+                              const stats = getVariantPatientStats(variant.id);
+                              if (stats.total === 0) return "—";
+                              const parts: string[] = [];
+                              if (stats.het > 0) parts.push(`${stats.het} het`);
+                              if (stats.hom > 0) parts.push(`${stats.hom} hom`);
+                              return parts.join(" / ");
+                            })()}
                           </td>
                         </tr>
                         {isExpanded && (
@@ -862,7 +882,12 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
                                                 title="Number of individuals with this variant assessed in published studies"
                                               >
                                                 <Users className="h-3 w-3" />
-                                                {paper.count} individual
+                                                {paper.zygosity === "Heterozygous"
+                                                  ? `${paper.count} het`
+                                                  : paper.zygosity === "Homozygous"
+                                                    ? `${paper.count} hom`
+                                                    : `${paper.count}`}{" "}
+                                                individual
                                                 {paper.count !== 1 ? "s" : ""} assessed
                                               </span>
                                             </div>

--- a/src/types/rna.ts
+++ b/src/types/rna.ts
@@ -59,9 +59,10 @@ export interface Literature {
 }
 
 export interface LiteratureCounts {
-  variant_id: string; // Reference to Variant.id
-  literature_id: string; // Reference to Literature.id
-  counts: number; // Number of citations/references
+  variant_id: string;
+  literature_id: string;
+  counts: number;
+  zygosity?: string;
 }
 
 // RNA Structure Interfaces


### PR DESCRIPTION
Adds patient observation counts with zygosity breakdown (heterozygous/homozygous) to variant display components.

### What changed

The API already returns zygosity data from `VariantClassification`, but the frontend was discarding it. These changes expose and display it.

| File | Change |
|------|--------|
| **`src/types/rna.ts`** | Added `zygosity?: string` to `LiteratureCounts` interface |
| **`src/components/VariantLiteratureCard.tsx`** | Added `getVariantPatientStats` helper; table row now shows `5 het / 3 hom` columns instead of just paper count; expanded literature entries show zygosity label |
| **`src/components/InfoPanel.tsx`** | Hovered variant literature section now shows per-entry zygosity count (`3 het`, `2 hom`) next to author/year |

### How it looks

**VariantLiteratureCard table:** The "Papers" column header is now "Patients" showing aggregated `{het} het / {hom} hom` per variant. Expanded rows show per-literature entries with zygosity labels.

**InfoPanel:** Literature entries under a hovered variant now display the patient count with zygosity (e.g., `3 het`) alongside the DOI link.

### Verification
- 50/50 frontend unit tests pass
- 122/122 backend tests pass
- Build succeeds (tsc + vite)
- All pre-commit hooks pass