### PR TITLE
fix: compound hets showing as dash in patient observation counts

### DIFF
--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -148,8 +148,14 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
   };
 
   const getLiteratureForVariant = (variantId: string) => {
-    const counts = literatureCounts.filter((lc) => lc.variant_id === variantId);
-    return counts
+    const directCounts = literatureCounts.filter((lc) => lc.variant_id === variantId);
+    const linkedCounts = literatureCounts.filter((lc) => {
+      if (!lc.linked_variant_ids) return false;
+      const linkedIds = lc.linked_variant_ids.split(",").map((id) => id.trim());
+      return linkedIds.includes(variantId);
+    });
+    const allCounts = [...directCounts, ...linkedCounts];
+    return allCounts
       .map((count) => {
         const literature = paperData.find((p) => p.id === count.literature_id);
         return literature

--- a/src/components/VariantLiteratureCard.tsx
+++ b/src/components/VariantLiteratureCard.tsx
@@ -100,10 +100,16 @@ const VariantLiteratureCard: React.FC<VariantLiteratureCardProps> = ({
   };
 
   const getVariantPatientStats = (variantId: string) => {
-    const counts = literatureCounts.filter((lc) => lc.variant_id === variantId);
+    const directCounts = literatureCounts.filter((lc) => lc.variant_id === variantId);
+    const linkedCounts = literatureCounts.filter((lc) => {
+      if (!lc.linked_variant_ids) return false;
+      const linkedIds = lc.linked_variant_ids.split(",").map((id) => id.trim());
+      return linkedIds.includes(variantId);
+    });
+    const allCounts = [...directCounts, ...linkedCounts];
     let het = 0;
     let hom = 0;
-    for (const c of counts) {
+    for (const c of allCounts) {
       if (c.zygosity === "Heterozygous") het += c.counts ?? 0;
       else if (c.zygosity === "Homozygous") hom += c.counts ?? 0;
     }

--- a/src/types/rna.ts
+++ b/src/types/rna.ts
@@ -63,6 +63,7 @@ export interface LiteratureCounts {
   literature_id: string;
   counts: number;
   zygosity?: string;
+  linked_variant_ids?: string;
 }
 
 // RNA Structure Interfaces


### PR DESCRIPTION
Fixes compound heterozygous variants showing `—` (dash) instead of patient counts in the variant table.

### Root Cause
`getVariantPatientStats` only searched `literatureCounts` by exact `variant_id` match. For compound hets, counts are stored under the primary variant's `VariantClassification` entry with `linked_variant_ids` pointing to the partner variant.

### Fix
- Added `linked_variant_ids` to the `LiteratureCounts` frontend type (API already returns it, type was missing)
- Updated `getVariantPatientStats` to also search entries where the variant appears in `linked_variant_ids`

Both variants in a compound het pair now correctly show the same patient counts.