### PR TITLE
Add visual connection lines between compound het variants in RNA Viewer

### DIFF
--- a/src/components/RNAViewer/RNAViewer.css
+++ b/src/components/RNAViewer/RNAViewer.css
@@ -28,6 +28,10 @@
   pointer-events: none;
 }
 
+.compound-het-lines-layer {
+  pointer-events: none;
+}
+
 .rna-controls {
   display: flex;
   gap: 8px;
@@ -83,5 +87,16 @@
   50% {
     r: 32;
     opacity: 0.5;
+  }
+}
+
+/* Compound het connection line animation */
+.compound-het-line {
+  animation: dash-flow 0.8s linear infinite;
+}
+
+@keyframes dash-flow {
+  to {
+    stroke-dashoffset: -10;
   }
 }

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -826,6 +826,31 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
             })}
           </g>
 
+          {selectedNucleotide && highlightedNucleotideIds.length > 0 && (
+            <g className="compound-het-lines-layer">
+              {highlightedNucleotideIds.map((highlightedId) => {
+                const highlightedNucleotide = rnaData.nucleotides.find(
+                  (n) => n.id === highlightedId,
+                );
+                if (!highlightedNucleotide) return null;
+                return (
+                  <line
+                    key={`comphet-${selectedNucleotide.id}-${highlightedId}`}
+                    x1={selectedNucleotide.x}
+                    y1={selectedNucleotide.y}
+                    x2={highlightedNucleotide.x}
+                    y2={highlightedNucleotide.y}
+                    stroke="#6366f1"
+                    strokeWidth="2.5"
+                    strokeDasharray="6,4"
+                    opacity="0.7"
+                    className="compound-het-line"
+                  />
+                );
+              })}
+            </g>
+          )}
+
           <g className="nucleotides-layer">
             {rnaData.nucleotides.map((nucleotide) => {
               const variantInfo = getVariantInfoForNucleotide(nucleotide.id);


### PR DESCRIPTION
## Description

When you click on a compound-het (biallelic) variant nucleotide in the RNA Viewer, the linked variant currently gets an indigo glow ring — but there's no **visual connecting line** between the two, making it hard to spot the linked partner in dense RNA structures.

This PR adds animated dashed indigo lines that connect the selected nucleotide to its linked variant nucleotide(s).

## Changes

### `src/components/RNAViewer/RNAViewer.tsx`
- New SVG `<g className="compound-het-lines-layer">` positioned between the bonds layer and nucleotides layer (lines are drawn **behind** the nucleotide circles)
- When `selectedNucleotide` is set and `highlightedNucleotideIds` is non-empty, dashed indigo lines are rendered from the selected nucleotide to each highlighted linked nucleotide

### `src/components/RNAViewer/RNAViewer.css`
- `.compound-het-lines-layer` — `pointer-events: none` to prevent interaction interference
- `.compound-het-line` — animated flowing dash effect via `@keyframes dash-flow`
- `@keyframes dash-flow` — infinite linear dash offset animation

## Visual Style
- **Color**: Indigo (#6366f1), matching the existing highlight color
- **Style**: Dashed (6,4 pattern), 2.5px stroke, 0.7 opacity
- **Animation**: Flowing dashes creating a directional visual cue
- **Interaction**: Lines are behind nucleotide circles and have pointer-events disabled

## Testing
- Click a nucleotide with linked variants → dashed lines appear to linked partners
- Click the same nucleotide again → lines disappear
- Click a different nucleotide → lines update to new targets
- Click a nucleotide without linked variants → no lines

Closes #203