### PR TITLE
fix: disease filter in RNA Viewer dropdown only shows diseases seen in that gene

### DIFF
--- a/api/routers/genes.py
+++ b/api/routers/genes.py
@@ -431,6 +431,23 @@ async def get_gene_variants(gene_id: str, db: Session = Depends(get_db)):
     return variants
 
 
+@router.get("/genes/{gene_id}/disease-types")
+async def get_gene_disease_types(gene_id: str, db: Session = Depends(get_db)):
+    """Get all distinct disease types for variants of a specific gene"""
+    rows = db.execute(
+        text("""
+            SELECT DISTINCT vc.disease
+            FROM variant_classifications vc
+            JOIN variants v ON vc.variant_id = v.id
+            WHERE v.geneId = :gene_id
+              AND vc.disease IS NOT NULL AND vc.disease != ''
+            ORDER BY vc.disease
+        """),
+        {"gene_id": gene_id},
+    ).fetchall()
+    return [row._mapping["disease"] for row in rows]
+
+
 @router.get("/genes/{gene_id}/literature", response_model=list[LiteraturePublic])
 async def get_gene_literature(gene_id: str, db: Session = Depends(get_db)):
     """Get all literature for a specific gene"""

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -32,7 +32,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import "./RNAViewer.css";
 import {
-  getDistinctDiseaseTypes,
+  getGeneDistinctDiseaseTypes,
   getDistinctClinicalSignificances,
 } from "@/services/api";
 
@@ -103,7 +103,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
     const fetchFilterOptions = async () => {
       try {
         const [diseases, significances] = await Promise.all([
-          getDistinctDiseaseTypes(),
+          getGeneDistinctDiseaseTypes(geneData.id),
           getDistinctClinicalSignificances(),
         ]);
         setDiseaseTypes(diseases);
@@ -113,7 +113,9 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
       }
     };
     fetchFilterOptions();
-  }, []);
+    setSelectedDiseaseType("all");
+    setSelectedClinicalSig("all");
+  }, [geneData.id]);
 
   const getFilteredOverlayValue = useCallback(
     (nucleotideId: number): { value: number; variant?: Variant } => {

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -216,4 +216,34 @@ describe("ApiService", () => {
       expect(result).toEqual(mockLiterature);
     });
   });
+
+  describe("getGeneDistinctDiseaseTypes", () => {
+    it("should return disease types for a gene", async () => {
+      const mockDiseases = ["Retinitis Pigmentosa", "ReNU Syndrome"];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve(mockDiseases),
+      });
+
+      const result = await apiService.getGeneDistinctDiseaseTypes("RNU4-2");
+
+      expect(result).toEqual(mockDiseases);
+      expect(mockFetch).toHaveBeenCalledWith("/api/genes/RNU4-2/disease-types", {
+        credentials: "include",
+      });
+    });
+
+    it("should return empty array when no diseases", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve([]),
+      });
+
+      const result = await apiService.getGeneDistinctDiseaseTypes("RNU4-2");
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -89,6 +89,10 @@ class ApiService {
     return this.fetchFromApi<string[]>("/variants/disease-types");
   }
 
+  async getGeneDistinctDiseaseTypes(geneId: string): Promise<string[]> {
+    return this.fetchFromApi<string[]>(`/genes/${geneId}/disease-types`);
+  }
+
   async getDistinctClinicalSignificances(): Promise<string[]> {
     return this.fetchFromApi<string[]>("/variants/clinical-significances");
   }
@@ -113,5 +117,7 @@ export const logout = () =>
     credentials: "include",
   });
 export const getDistinctDiseaseTypes = () => apiService.getDistinctDiseaseTypes();
+export const getGeneDistinctDiseaseTypes = (geneId: string) =>
+  apiService.getGeneDistinctDiseaseTypes(geneId);
 export const getDistinctClinicalSignificances = () =>
   apiService.getDistinctClinicalSignificances();

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,6 +69,29 @@ class TestGenesAPI:
         assert response.status_code in (200, 404)
 
 
+class TestGeneDiseaseTypesAPI:
+    """Tests for gene-scoped disease types API endpoint."""
+
+    def test_get_gene_disease_types_scoped(
+        self, test_client, sample_variant_classification
+    ):
+        """GET /api/genes/{gene_id}/disease-types returns diseases for that gene."""
+        response = test_client.get("/api/genes/RNU4-2/disease-types")
+        assert response.status_code == 200
+        data = response.json()
+        assert "Retinitis Pigmentosa" in data
+
+        response_other = test_client.get("/api/genes/NONEXISTENT/disease-types")
+        assert response_other.status_code == 200
+        assert response_other.json() == []
+
+    def test_get_gene_disease_types_empty(self, test_client, seed_gene):
+        """GET /api/genes/{gene_id}/disease-types returns [] when no classifications."""
+        response = test_client.get("/api/genes/RNU4-2/disease-types")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
 class TestGeneStructuresAPI:
     """Tests for gene structures API endpoints - regression tests for 404 issue."""
 


### PR DESCRIPTION
## Description

Fixes #204 — the disease filter dropdown in the RNA Viewer was showing **all** diseases across **all genes** in the database. Now it only shows diseases that are associated with variants of the currently selected gene.

## Changes

### Backend
- New `GET /api/genes/{gene_id}/disease-types` endpoint in `api/routers/genes.py` — joins `variant_classifications` → `variants` → `genes` to return only diseases for a specific gene

### Frontend
- `src/services/api.ts`: Added `getGeneDistinctDiseaseTypes(geneId)` method and export
- `src/components/RNAViewer/RNAViewer.tsx`: Switched from global `getDistinctDiseaseTypes()` to gene-scoped `getGeneDistinctDiseaseTypes(geneData.id)`, with `geneData.id` as a dependency so the filter reloads on gene change. Also resets selected filters when gene changes.

### Tests
- `tests/test_api.py`: `TestGeneDiseaseTypesAPI` — tests scoped retrieval and empty result
- `src/services/api.test.ts`: `getGeneDistinctDiseaseTypes` — tests success and empty array

## Verification
- [x] `uv run pytest` — 38 tests passed
- [x] `npm run build` — compiles cleanly
- [x] `npx vitest run` — 16 tests passed
- [x] `pre-commit run --all-files` — all hooks passed