### PR TITLE
fix: prevent structure import from silently overwriting existing data (#202)

### DIFF
--- a/api/routers/imports.py
+++ b/api/routers/imports.py
@@ -13,6 +13,7 @@ from api.models import (
     Gene,
     ImportResult,
     Literature,
+    RNAStructure,
     StructureImportRequest,
     ValidationErrorModel,
     ValidationReportResponse,
@@ -196,7 +197,22 @@ async def validate_structure_import(
         raise HTTPException(status_code=404, detail=f"Gene {request.geneId} not found")
 
     report = validate_structure(request.structure, gene)
-    return _validation_report_to_response(report)
+    response = _validation_report_to_response(report)
+    existing = db.get(RNAStructure, request.structure["id"])
+    if existing:
+        response.warnings.append(
+            ValidationErrorModel(
+                row=0,
+                field="id",
+                message=(
+                    f"Structure '{request.structure['id']}' already exists"
+                    f" for gene {existing.geneId}."
+                    " Importing will overwrite the existing structure."
+                ),
+                value=request.structure["id"],
+            )
+        )
+    return response
 
 
 @router.post("/imports/structures", response_model=ImportResult)
@@ -219,6 +235,21 @@ async def import_structure(
                     {"row": e.row, "field": e.field, "message": e.message}
                     for e in report.errors
                 ],
+            },
+        )
+
+    existing = db.get(RNAStructure, request.structure["id"])
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": (
+                    f"Structure '{request.structure['id']}' already exists"
+                    f" for gene {existing.geneId}."
+                    " Delete it first or use a different ID."
+                ),
+                "existing_id": request.structure["id"],
+                "gene_id": existing.geneId,
             },
         )
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -133,6 +133,43 @@ class TestStructureImportAPI:
         assert data["success"] is True
         assert data["imported_count"] == 1
 
+    def test_validate_duplicate_structure_warns(
+        self, test_client, seed_gene, valid_structure_data
+    ):
+        """Validating a structure whose ID already exists should return a warning."""
+        test_client.post(
+            "/api/imports/structures",
+            json={"geneId": "RNU4-2", "structure": valid_structure_data},
+        )
+        response = test_client.post(
+            "/api/imports/structures/validate",
+            json={"geneId": "RNU4-2", "structure": valid_structure_data},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["warnings"]) >= 1
+        warning_messages = [w["message"] for w in data["warnings"]]
+        assert any("already exists" in msg for msg in warning_messages)
+
+    def test_import_duplicate_structure_rejected(
+        self, test_client, seed_gene, valid_structure_data
+    ):
+        """Importing a structure with an existing ID should return 409."""
+        response = test_client.post(
+            "/api/imports/structures",
+            json={"geneId": "RNU4-2", "structure": valid_structure_data},
+        )
+        assert response.status_code == 200
+
+        response = test_client.post(
+            "/api/imports/structures",
+            json={"geneId": "RNU4-2", "structure": valid_structure_data},
+        )
+        assert response.status_code == 409
+        data = response.json()
+        assert "already exists" in data["detail"]["message"]
+        assert data["detail"]["existing_id"] == "rnu4-2-test"
+
 
 class TestBEDTrackImportAPI:
     """Test BED track import endpoints."""


### PR DESCRIPTION
## Description

Fixes #202 — importing a structure with an existing ID silently overwrote the existing structure (and all children: nucleotides, base_pairs, annotations, structural_features) via `session.merge()`.

## Changes

### `api/routers/imports.py` — Two layers of protection

1. **Validate endpoint (`POST /imports/structures/validate`)**: Now checks if a structure with the same ID already exists and returns a warning. Users see this during the validation step (Step 3 of the import wizard) before attempting import.

2. **Import endpoint (`POST /imports/structures`)**: Now checks if a structure with the same ID already exists and returns `HTTP 409 Conflict` with a clear message. The existing structure is never overwritten.

### `tests/test_imports.py` — Two new tests

- `test_validate_duplicate_structure_warns`: Imports a structure, then validates the same structure again — asserts a warning is returned about the existing ID.
- `test_import_duplicate_structure_rejected`: Imports a structure, then tries importing the same structure again — asserts `409 Conflict` with the correct error details.

## What was NOT changed

- `rnudb_utils/database.py` — the `merge()` behavior is fine for seed scripts that call `insert_structures()` directly; the fix only blocks at the API layer
- `src/components/Curate/StructureImportWizard.tsx` — already handles non-ok responses and displays `detail.message` to the user
- Editor export flow — entirely client-side (JSON download), no backend interaction

## Verification

- [x] `uv run pytest` — 126 passed, 2 skipped (pre-existing)
- [x] `npm run build` — compiles cleanly
- [x] `pre-commit run --all-files` — all hooks passed