### PR TITLE
fix: function score track sync and linear view + button page reload (#215, #219)

### DIFF
--- a/src/components/GenomeBrowser/DomainsTrack.tsx
+++ b/src/components/GenomeBrowser/DomainsTrack.tsx
@@ -63,7 +63,11 @@ const DomainsTrack: React.FC<DomainsTrackProps> = ({ domains, regions, geneStart
   return (
     <Track title="Domains">
       {({ scalePosition, width }) => (
-        <svg height={height} width={width}>
+        <svg
+          height={height}
+          width={width}
+          style={{ display: "block", overflow: "visible" }}
+        >
           <rect x={0} y={0} width={width} height={height} fill="white" />
           <line
             x1={0}

--- a/src/components/GenomeBrowser/FunctionScoreTrack.tsx
+++ b/src/components/GenomeBrowser/FunctionScoreTrack.tsx
@@ -86,7 +86,11 @@ const FunctionScoreTrack: React.FC<FunctionScoreTrackProps> = ({
   return (
     <Track title="Function Score">
       {({ scalePosition, width }) => (
-        <svg height={height} width={width}>
+        <svg
+          height={height}
+          width={width}
+          style={{ display: "block", overflow: "visible" }}
+        >
           <rect
             x={0}
             y={0}

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -156,6 +156,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
             variant="outline"
             size="sm"
             className="h-8 px-3"
+            type="button"
           >
             <ZoomIn className="h-3 w-3" />
           </Button>
@@ -164,6 +165,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
             variant="outline"
             size="sm"
             className="h-8 px-3"
+            type="button"
           >
             <ZoomOut className="h-3 w-3" />
           </Button>
@@ -172,6 +174,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
             variant="outline"
             size="sm"
             className="h-8 px-3"
+            type="button"
           >
             <RotateCcw className="h-3 w-3" />
           </Button>
@@ -187,6 +190,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
             variant="outline"
             size="sm"
             className="h-8 px-3"
+            type="button"
           >
             <Download className="h-3 w-3 mr-1" />
             <span className="text-xs">SVG</span>
@@ -196,6 +200,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
             variant="outline"
             size="sm"
             className="h-8 px-3"
+            type="button"
           >
             <FileImage className="h-3 w-3 mr-1" />
             <span className="text-xs">PNG</span>

--- a/src/components/GenomeBrowser/SequenceTrack.tsx
+++ b/src/components/GenomeBrowser/SequenceTrack.tsx
@@ -51,7 +51,11 @@ const SequenceTrack: React.FC<SequenceTrackProps> = ({
   return (
     <Track title="Reference Sequence">
       {({ scalePosition, width }) => (
-        <svg height={height} width={width}>
+        <svg
+          height={height}
+          width={width}
+          style={{ display: "block", overflow: "visible" }}
+        >
           <rect
             width={width}
             height={height}


### PR DESCRIPTION
## Summary

Fixes two bugs in the linear view (GenomeBrowser):

### #215 — Function scores don't move in sync with the linear view

**Root cause**: The `FunctionScoreTrack` SVG rendered with default `overflow: hidden` and inline-element spacing, which caused visual misalignment between the function score dots and the rest of the tracks when the viewport changed (zoom/scroll/pan navigation).

**Fix**: Added `style={{ display: block, overflow: visible }}` to the SVG elements in `FunctionScoreTrack`, `DomainsTrack`, and `SequenceTrack` to ensure consistent rendering and prevent clipping of track content.

### #219 — Linear view reloads entire page when pressing + after interaction

**Root cause**: The `Button` component in `button.tsx` doesn't set `type="button"`, so it defaults to `type="submit"`. After interacting with the `Cursor` (which triggers a React re-render), clicking the zoom-in button could trigger a form submission event, causing a full page reload.

**Fix**: Added `type="button"` to all 5 toolbar buttons (ZoomIn, ZoomOut, Reset, Export SVG, Export PNG) in `GenomeBrowser.tsx`.

## Changes

| File | Change |
|------|--------|
| `src/components/GenomeBrowser/GenomeBrowser.tsx` | Add `type="button"` to all toolbar buttons |
| `src/components/GenomeBrowser/FunctionScoreTrack.tsx` | Add `display: block; overflow: visible` to SVG |
| `src/components/GenomeBrowser/DomainsTrack.tsx` | Add `display: block; overflow: visible` to SVG |
| `src/components/GenomeBrowser/SequenceTrack.tsx` | Add `display: block; overflow: visible` to SVG |

Closes #215, Closes #219