### PR TITLE
fix: remove PDB API request causing 404 on gene page

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -7,7 +7,6 @@ import type {
   SnRNAGene,
   RNAStructure,
   Nucleotide,
-  PDBStructure,
   LiteratureCounts,
 } from "../types";
 import GenomeBrowser from "./GenomeBrowser";
@@ -25,7 +24,6 @@ import {
 interface MainContentProps {
   currentData: SnRNAGene;
   rnaStructureData: RNAStructure | null;
-  pdbStructureData: PDBStructure | null;
   paperData: Literature[];
   literatureCounts: LiteratureCounts[];
   variantData: Variant[];
@@ -39,7 +37,6 @@ interface MainContentProps {
 const MainContent: React.FC<MainContentProps> = ({
   currentData,
   rnaStructureData,
-  pdbStructureData,
   paperData,
   literatureCounts,
   variantData,
@@ -176,7 +173,6 @@ const MainContent: React.FC<MainContentProps> = ({
               <CardContent>
                 <RNAViewer
                   rnaData={getRNAData()}
-                  pdbData={pdbStructureData}
                   overlayData={getCurrentOverlayData()}
                   overlayMode={overlayMode}
                   onCycleOverlay={cycleOverlayMode}

--- a/src/data/structures.ts
+++ b/src/data/structures.ts
@@ -1,5 +1,5 @@
 // Structure data utilities
-import { getGeneStructure, getGenePDB } from "../services/api";
+import { getGeneStructure } from "../services/api";
 import type { RNAStructure } from "../types";
 
 export const getRNAStructure = async (geneId: string): Promise<RNAStructure | null> => {
@@ -7,18 +7,6 @@ export const getRNAStructure = async (geneId: string): Promise<RNAStructure | nu
     return await getGeneStructure(geneId);
   } catch (error) {
     console.error(`Error fetching structure for ${geneId}:`, error);
-    return null;
-  }
-};
-
-export const getPDBStructure = async (
-  geneId: string,
-): Promise<{ geneId: string; pdbData: string } | null> => {
-  try {
-    const result = await getGenePDB(geneId);
-    return result;
-  } catch (error) {
-    console.error(`Error fetching PDB for ${geneId}:`, error);
     return null;
   }
 };

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -7,7 +7,6 @@ import { useAuth } from "../context/AuthContext";
 import { getGeneData } from "../data/genes";
 import { getLiterature } from "../data/literature";
 import { getRNAStructure } from "../data/structures";
-import { getPDBStructure } from "../data/structures";
 import { getVariants } from "../data/variants";
 import { COLORBLIND_FRIENDLY_PALETTE } from "../lib/colors";
 import { getLiteratureCounts } from "../services/api";
@@ -18,7 +17,6 @@ import type {
   Literature,
   LiteratureCounts,
   RNAStructure,
-  PDBStructure,
 } from "../types";
 import { Button } from "@/components/ui/button";
 
@@ -46,7 +44,6 @@ const Gene: React.FC = () => {
   const [paperData, setPaperData] = useState<Literature[]>([]);
   const [literatureCounts, setLiteratureCounts] = useState<LiteratureCounts[]>([]);
   const [rnaStructureData, setRnaStructureData] = useState<RNAStructure | null>(null);
-  const [pdbData, setPdbData] = useState<PDBStructure | null>(null);
 
   // Load data when selectedSnRNA changes
   useEffect(() => {
@@ -57,21 +54,14 @@ const Gene: React.FC = () => {
       setError(null);
 
       try {
-        const [
-          gene,
-          variants,
-          literature,
-          literatureCountsData,
-          rnaStructure,
-          pdbStructure,
-        ] = await Promise.all([
-          getGeneData(selectedSnRNA),
-          getVariants(selectedSnRNA),
-          getLiterature(selectedSnRNA),
-          getLiteratureCounts(),
-          getRNAStructure(selectedSnRNA),
-          getPDBStructure(selectedSnRNA),
-        ]);
+        const [gene, variants, literature, literatureCountsData, rnaStructure] =
+          await Promise.all([
+            getGeneData(selectedSnRNA),
+            getVariants(selectedSnRNA),
+            getLiterature(selectedSnRNA),
+            getLiteratureCounts(),
+            getRNAStructure(selectedSnRNA),
+          ]);
 
         if (!gene) {
           throw new Error(`Gene ${selectedSnRNA} not found`);
@@ -82,7 +72,6 @@ const Gene: React.FC = () => {
         setPaperData(literature);
         setLiteratureCounts(literatureCountsData);
         setRnaStructureData(rnaStructure);
-        setPdbData(pdbStructure);
       } catch (err) {
         console.error("Error loading gene data:", err);
         setError(err instanceof Error ? err.message : "Failed to load gene data");
@@ -313,7 +302,6 @@ const Gene: React.FC = () => {
           <MainContent
             currentData={currentData}
             rnaStructureData={rnaStructureData}
-            pdbStructureData={pdbData}
             paperData={paperData}
             literatureCounts={literatureCounts}
             variantData={variantData}


### PR DESCRIPTION
Removes the  call from the gene page's  and cleans up unused PDB-related code in , , and . The PDB endpoint returns 404 for most genes, and the error was causing a React crash and blank page.