### PR TITLE
fix: restore Vite 6/7 CJS interop for @gnomad packages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,7 @@ export default defineConfig({
       '/api': 'http://localhost:8000',
     },
   },
+  legacy: {
+    inconsistentCjsInterop: true,
+  } as any,
 });


### PR DESCRIPTION
## Problem

Vite 8 (bumped in #192) changed how default imports from CommonJS modules work. With the project's `"type": "module"` in package.json, default imports like `import VariantTrack from "@gnomad/track-variants"` now resolve to the entire `module.exports` object instead of `module.exports.default`. This causes React error #130 (`Element type is invalid: expected a string/function but got object`) because the imported value is an object, not a component function.

## Fix

Added `legacy.inconsistentCjsInterop: true` to vite.config.ts to restore the previous CJS interop behavior. This is a deprecated Vite 8 option that will be removed in a future version, at which point we should migrate to explicit named imports.

## Affected imports

- `import VariantTrack from "@gnomad/track-variants"` (SnRNAVariantTrack.tsx, CuratorVariantTrack.tsx)
- `import domtoimage from "dom-to-image-more"` (GenomeBrowser.tsx)

Named imports from `@gnomad/region-viewer` (`{ RegionViewer, Track, Cursor }`) are unaffected.