### PR TITLE
fix: force SVG remount on region change to prevent stale dot accumulation (#215)

### DIFF
--- a/src/components/GenomeBrowser/DomainsTrack.tsx
+++ b/src/components/GenomeBrowser/DomainsTrack.tsx
@@ -64,6 +64,7 @@ const DomainsTrack: React.FC<DomainsTrackProps> = ({ domains, regions, geneStart
     <Track title="Domains">
       {({ scalePosition, width }) => (
         <svg
+          key={`${currentRegion.start}-${currentRegion.stop}`}
           height={height}
           width={width}
           style={{ display: "block", overflow: "visible" }}

--- a/src/components/GenomeBrowser/FunctionScoreTrack.tsx
+++ b/src/components/GenomeBrowser/FunctionScoreTrack.tsx
@@ -87,6 +87,7 @@ const FunctionScoreTrack: React.FC<FunctionScoreTrackProps> = ({
     <Track title="Function Score">
       {({ scalePosition, width }) => (
         <svg
+          key={`${currentRegion.start}-${currentRegion.stop}`}
           height={height}
           width={width}
           style={{ display: "block", overflow: "visible" }}


### PR DESCRIPTION
## Description

Fixes issue #215 — Function Score dot plot accumulates stale dots when panning, creating a messy cluster.

## Root Cause

When the genome browser region changes (user pans left/right), React re-renders the `<svg>` in-place. React's SVG reconciliation does not reliably remove old `<circle>` elements from the DOM, so they persist. The previous fix (PR #231) added `overflow: visible` which made the problem visible instead of clipped.

## Fix

Added a `key` prop to the `<svg>` element in both `FunctionScoreTrack.tsx` and `DomainsTrack.tsx`, keyed on `${currentRegion.start}-${currentRegion.stop}`. This forces React to **unmount the old SVG DOM node and mount a fresh one** whenever the region changes, guaranteeing zero stale elements survive across pans.

## Changes

- **FunctionScoreTrack.tsx** — added `key` to `<svg>`
- **DomainsTrack.tsx** — same fix for consistency (same pattern, same bug risk)