### PR TITLE
feat: two-way zoom and highlight between RNA structure and genome browser (#220)

### DIFF
--- a/src/components/GenomeBrowser/DomainsTrack.tsx
+++ b/src/components/GenomeBrowser/DomainsTrack.tsx
@@ -28,9 +28,17 @@ interface DomainsTrackProps {
   domains: StructuralFeature[];
   regions: { start: number; stop: number }[];
   geneStart: number;
+  geneStrand: string;
+  geneEnd: number;
 }
 
-const DomainsTrack: React.FC<DomainsTrackProps> = ({ domains, regions, geneStart }) => {
+const DomainsTrack: React.FC<DomainsTrackProps> = ({
+  domains,
+  regions,
+  geneStart,
+  geneStrand,
+  geneEnd,
+}) => {
   const height = 34;
   const currentRegion = regions[0];
 
@@ -40,6 +48,9 @@ const DomainsTrack: React.FC<DomainsTrackProps> = ({ domains, regions, geneStart
   };
 
   const getGenomicPos = (nucleotideId: number): number => {
+    if (geneStrand === "-") {
+      return geneEnd - nucleotideId + 1;
+    }
     return geneStart + nucleotideId - 1;
   };
 

--- a/src/components/GenomeBrowser/DomainsTrack.tsx
+++ b/src/components/GenomeBrowser/DomainsTrack.tsx
@@ -60,8 +60,11 @@ const DomainsTrack: React.FC<DomainsTrackProps> = ({
       if (ids.length === 0) return null;
       const startNuc = Math.min(...ids);
       const endNuc = Math.max(...ids);
-      const genomicStart = getGenomicPos(startNuc);
-      const genomicEnd = getGenomicPos(endNuc);
+      let genomicStart = getGenomicPos(startNuc);
+      let genomicEnd = getGenomicPos(endNuc);
+      if (genomicStart > genomicEnd) {
+        [genomicStart, genomicEnd] = [genomicEnd, genomicStart];
+      }
       return { feature, genomicStart, genomicEnd };
     })
     .filter(

--- a/src/components/GenomeBrowser/FunctionScoreTrack.tsx
+++ b/src/components/GenomeBrowser/FunctionScoreTrack.tsx
@@ -50,7 +50,10 @@ const FunctionScoreTrack: React.FC<FunctionScoreTrackProps> = ({
     )
     .map((v) => ({
       nucleotidePos: getNucleotidePos(v)!,
-      genomicPos: geneStart + getNucleotidePos(v)! - 1,
+      genomicPos:
+        geneStrand === "-" && geneEnd != null
+          ? geneEnd - getNucleotidePos(v)! + 1
+          : geneStart + getNucleotidePos(v)! - 1,
       value: v.function_score!,
       variantId: v.id,
       hgvs: v.hgvs,

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -32,6 +32,8 @@ interface GenomeBrowserProps {
     strand: string;
     sequence: string;
   };
+  selectedVariantPosition?: number | null;
+  onVariantNavigate?: (genomicPosition: number) => void;
 }
 
 const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
@@ -41,6 +43,8 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
   aouVariants,
   structuralFeatures,
   geneData,
+  selectedVariantPosition,
+  onVariantNavigate,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<HTMLDivElement>(null);
@@ -50,6 +54,20 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
   const [zygosityFilter, setZygosityFilter] = useState<string>("all");
   const defaultRegion = { start: geneData.start, stop: geneData.end };
   const [regions, setRegions] = useState([defaultRegion]);
+
+  useEffect(() => {
+    if (selectedVariantPosition != null) {
+      const currentRegion = regions[0];
+      const halfRange = Math.round((currentRegion.stop - currentRegion.start) / 2);
+      setRegions([
+        {
+          start: Math.round(selectedVariantPosition) - halfRange,
+          stop: Math.round(selectedVariantPosition) + halfRange,
+        },
+      ]);
+      setIsZoomed(true);
+    }
+  }, [selectedVariantPosition]);
 
   useEffect(() => {
     const updateWidth = () => {
@@ -274,13 +292,15 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
                 const halfRange = Math.round(
                   (currentRegion.stop - currentRegion.start) / 2,
                 );
+                const rounded = Math.round(cursorPosition);
                 setRegions([
                   {
-                    start: Math.round(cursorPosition) - halfRange,
-                    stop: Math.round(cursorPosition) + halfRange,
+                    start: rounded - halfRange,
+                    stop: rounded + halfRange,
                   },
                 ]);
                 setIsZoomed(true);
+                onVariantNavigate?.(rounded);
               }
             }}
             onDrag={(start, end) => {
@@ -307,6 +327,7 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
               aouVariants={aouVariants}
               sourceFilter={sourceFilter}
               zygosityFilter={zygosityFilter}
+              selectedVariantPosition={selectedVariantPosition}
             />
           </Cursor>
         </RegionViewer>

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -302,8 +302,11 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
               }
             }}
             onDrag={(start, end) => {
-              setRegions([{ start: Math.round(start), stop: Math.round(end) }]);
+              const roundedStart = Math.round(start);
+              const roundedEnd = Math.round(end);
+              setRegions([{ start: roundedStart, stop: roundedEnd }]);
               setIsZoomed(true);
+              onVariantNavigate?.(Math.round((roundedStart + roundedEnd) / 2));
             }}
             renderCursor={renderCustomCursor}
           >

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -57,12 +57,10 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
 
   useEffect(() => {
     if (selectedVariantPosition != null) {
-      const currentRegion = regions[0];
-      const halfRange = Math.round((currentRegion.stop - currentRegion.start) / 2);
       setRegions([
         {
-          start: Math.round(selectedVariantPosition) - halfRange,
-          stop: Math.round(selectedVariantPosition) + halfRange,
+          start: Math.round(selectedVariantPosition) - 75,
+          stop: Math.round(selectedVariantPosition) + 75,
         },
       ]);
       setIsZoomed(true);

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -59,8 +59,8 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
     if (selectedVariantPosition != null) {
       setRegions([
         {
-          start: Math.round(selectedVariantPosition) - 75,
-          stop: Math.round(selectedVariantPosition) + 75,
+          start: Math.round(selectedVariantPosition) - 2,
+          stop: Math.round(selectedVariantPosition) + 2,
         },
       ]);
       setIsZoomed(true);

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -306,7 +306,6 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
               const roundedEnd = Math.round(end);
               setRegions([{ start: roundedStart, stop: roundedEnd }]);
               setIsZoomed(true);
-              onVariantNavigate?.(Math.round((roundedStart + roundedEnd) / 2));
             }}
             renderCursor={renderCustomCursor}
           >

--- a/src/components/GenomeBrowser/GenomeBrowser.tsx
+++ b/src/components/GenomeBrowser/GenomeBrowser.tsx
@@ -311,6 +311,8 @@ const GenomeBrowser: React.FC<GenomeBrowserProps> = ({
               domains={structuralFeatures}
               regions={regions}
               geneStart={geneData.start}
+              geneStrand={geneData.strand}
+              geneEnd={geneData.end}
             />
             <FunctionScoreTrack
               variants={variants}

--- a/src/components/GenomeBrowser/SnRNAVariantTrack.tsx
+++ b/src/components/GenomeBrowser/SnRNAVariantTrack.tsx
@@ -9,6 +9,7 @@ interface SnRNAVariantTrackProps {
   aouVariants: any[];
   sourceFilter?: string;
   zygosityFilter?: string;
+  selectedVariantPosition?: number | null;
 }
 
 const passesZygosity = (
@@ -30,7 +31,10 @@ const SnRNAVariantTrack: React.FC<SnRNAVariantTrackProps> = ({
   aouVariants,
   sourceFilter = "all",
   zygosityFilter = "all",
+  selectedVariantPosition,
 }) => {
+  const isSelectedPos = (pos: number) =>
+    selectedVariantPosition != null && pos === selectedVariantPosition;
   // Transform clinical variants to the format expected by gnomAD VariantTrack
   const clinvarVariants = variants
     .filter(
@@ -48,6 +52,7 @@ const SnRNAVariantTrack: React.FC<SnRNAVariantTrackProps> = ({
       consequence: variant.consequence || "unknown",
       clinical_significance: variant.clinical_significance,
       isHighlighted:
+        isSelectedPos(variant.position) ||
         variant.clinical_significance === "Pathogenic" ||
         variant.clinical_significance === "Likely Pathogenic" ||
         variant.clinical_significance === "PATH" ||
@@ -67,7 +72,7 @@ const SnRNAVariantTrack: React.FC<SnRNAVariantTrackProps> = ({
       alt: variant.alt,
       allele_freq: (variant.gnomad_ac || 0) / 1000000,
       consequence: variant.consequence || "unknown",
-      isHighlighted: false,
+      isHighlighted: isSelectedPos(variant.position),
     }));
 
   // Filter and transform All of Us variants
@@ -83,7 +88,7 @@ const SnRNAVariantTrack: React.FC<SnRNAVariantTrackProps> = ({
       alt: variant.alt,
       allele_freq: (variant.aou_ac || 0) / 1000000,
       consequence: variant.consequence || "unknown",
-      isHighlighted: false,
+      isHighlighted: isSelectedPos(variant.position),
     }));
 
   const showGnomad = sourceFilter === "all" || sourceFilter === "gnomad";

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -52,6 +52,7 @@ const MainContent: React.FC<MainContentProps> = ({
     [],
   );
   const [selectedVariantPos, setSelectedVariantPos] = useState<number | null>(null);
+  const [genomeBrowserFocusId, setGenomeBrowserFocusId] = useState<number | null>(null);
 
   const computeGenomicPos = (nucleotideId: number): number => {
     if (currentData.strand === "-") {
@@ -126,6 +127,7 @@ const MainContent: React.FC<MainContentProps> = ({
 
   const handleGenomeBrowserNavigate = (genomicPos: number) => {
     const nucleotideId = computeNucleotideId(genomicPos);
+    setGenomeBrowserFocusId(nucleotideId);
     const nucleotide = rnaStructureData?.nucleotides.find((n) => n.id === nucleotideId);
     if (nucleotide) {
       handleNucleotideClick(nucleotide);
@@ -207,6 +209,7 @@ const MainContent: React.FC<MainContentProps> = ({
                   onNucleotideClick={handleNucleotideClick}
                   selectedNucleotide={selectedNucleotide}
                   highlightedNucleotideIds={highlightedNucleotideIds}
+                  focusNucleotideId={genomeBrowserFocusId}
                   geneData={{
                     id: currentData.id,
                     name: currentData.name,

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -52,7 +52,6 @@ const MainContent: React.FC<MainContentProps> = ({
     [],
   );
   const [selectedVariantPos, setSelectedVariantPos] = useState<number | null>(null);
-  const [genomeBrowserFocusId, setGenomeBrowserFocusId] = useState<number | null>(null);
 
   const computeGenomicPos = (nucleotideId: number): number => {
     if (currentData.strand === "-") {
@@ -127,7 +126,6 @@ const MainContent: React.FC<MainContentProps> = ({
 
   const handleGenomeBrowserNavigate = (genomicPos: number) => {
     const nucleotideId = computeNucleotideId(genomicPos);
-    setGenomeBrowserFocusId(nucleotideId);
     const nucleotide = rnaStructureData?.nucleotides.find((n) => n.id === nucleotideId);
     if (nucleotide) {
       handleNucleotideClick(nucleotide);
@@ -209,7 +207,6 @@ const MainContent: React.FC<MainContentProps> = ({
                   onNucleotideClick={handleNucleotideClick}
                   selectedNucleotide={selectedNucleotide}
                   highlightedNucleotideIds={highlightedNucleotideIds}
-                  focusNucleotideId={genomeBrowserFocusId}
                   geneData={{
                     id: currentData.id,
                     name: currentData.name,

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -51,11 +51,27 @@ const MainContent: React.FC<MainContentProps> = ({
   const [highlightedNucleotideIds, setHighlightedNucleotideIds] = useState<number[]>(
     [],
   );
+  const [selectedVariantPos, setSelectedVariantPos] = useState<number | null>(null);
+
+  const computeGenomicPos = (nucleotideId: number): number => {
+    if (currentData.strand === "-") {
+      return currentData.end - nucleotideId + 1;
+    }
+    return currentData.start + nucleotideId - 1;
+  };
+
+  const computeNucleotideId = (genomicPos: number): number => {
+    if (currentData.strand === "-") {
+      return currentData.end - genomicPos + 1;
+    }
+    return genomicPos - currentData.start + 1;
+  };
 
   const handleNucleotideClick = (nucleotide: Nucleotide) => {
     if (selectedNucleotide?.id === nucleotide.id) {
       setSelectedNucleotide(null);
       setHighlightedNucleotideIds([]);
+      setSelectedVariantPos(null);
     } else {
       setSelectedNucleotide(nucleotide);
       const variantsAtPosition = variantData.filter((variant) => {
@@ -104,6 +120,15 @@ const MainContent: React.FC<MainContentProps> = ({
         }
       }
       setHighlightedNucleotideIds(linkedIds);
+      setSelectedVariantPos(computeGenomicPos(nucleotide.id));
+    }
+  };
+
+  const handleGenomeBrowserNavigate = (genomicPos: number) => {
+    const nucleotideId = computeNucleotideId(genomicPos);
+    const nucleotide = rnaStructureData?.nucleotides.find((n) => n.id === nucleotideId);
+    if (nucleotide) {
+      handleNucleotideClick(nucleotide);
     }
   };
 
@@ -224,6 +249,8 @@ const MainContent: React.FC<MainContentProps> = ({
                   strand: currentData.strand,
                   sequence: currentData.sequence,
                 }}
+                selectedVariantPosition={selectedVariantPos}
+                onVariantNavigate={handleGenomeBrowserNavigate}
               />
             </CardContent>
           </Card>

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -48,7 +48,6 @@ interface RNAViewerProps {
   gnomadVariants?: Variant[];
   selectedNucleotide?: Nucleotide | null;
   highlightedNucleotideIds?: number[];
-  focusNucleotideId?: number | null;
   geneData: {
     id: string;
     name: string;
@@ -77,7 +76,6 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
   gnomadVariants = [],
   selectedNucleotide = null,
   highlightedNucleotideIds = [],
-  focusNucleotideId,
   geneData,
 }) => {
   const [hoveredNucleotide, setHoveredNucleotide] = useState<Nucleotide | null>(null);
@@ -120,30 +118,6 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
     setSelectedDiseaseType("all");
     setSelectedClinicalSig("all");
   }, [geneData.id]);
-
-  useEffect(() => {
-    if (focusNucleotideId == null || !containerRef.current || !svgRef.current) return;
-
-    const nucleotide = rnaData.nucleotides.find((n) => n.id === focusNucleotideId);
-    if (!nucleotide) return;
-
-    const viewBox = svgRef.current.viewBox.baseVal;
-    const viewBoxCenterX = viewBox.x + viewBox.width / 2;
-    const viewBoxCenterY = viewBox.y + viewBox.height / 2;
-
-    const containerWidth = containerRef.current.clientWidth;
-    const containerHeight = containerRef.current.clientHeight;
-
-    const scaleX = containerWidth / viewBox.width;
-    const scaleY = containerHeight / viewBox.height;
-
-    const targetZoom = 2.5;
-    setZoomLevel(targetZoom);
-    setPanOffset({
-      x: -(nucleotide.x - viewBoxCenterX) * scaleX * targetZoom,
-      y: -(nucleotide.y - viewBoxCenterY) * scaleY * targetZoom,
-    });
-  }, [focusNucleotideId]);
 
   const getFilteredOverlayValue = useCallback(
     (nucleotideId: number): { value: number; variant?: Variant } => {

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -48,6 +48,7 @@ interface RNAViewerProps {
   gnomadVariants?: Variant[];
   selectedNucleotide?: Nucleotide | null;
   highlightedNucleotideIds?: number[];
+  focusNucleotideId?: number | null;
   geneData: {
     id: string;
     name: string;
@@ -76,6 +77,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
   gnomadVariants = [],
   selectedNucleotide = null,
   highlightedNucleotideIds = [],
+  focusNucleotideId,
   geneData,
 }) => {
   const [hoveredNucleotide, setHoveredNucleotide] = useState<Nucleotide | null>(null);
@@ -118,6 +120,30 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
     setSelectedDiseaseType("all");
     setSelectedClinicalSig("all");
   }, [geneData.id]);
+
+  useEffect(() => {
+    if (focusNucleotideId == null || !containerRef.current || !svgRef.current) return;
+
+    const nucleotide = rnaData.nucleotides.find((n) => n.id === focusNucleotideId);
+    if (!nucleotide) return;
+
+    const viewBox = svgRef.current.viewBox.baseVal;
+    const viewBoxCenterX = viewBox.x + viewBox.width / 2;
+    const viewBoxCenterY = viewBox.y + viewBox.height / 2;
+
+    const containerWidth = containerRef.current.clientWidth;
+    const containerHeight = containerRef.current.clientHeight;
+
+    const scaleX = containerWidth / viewBox.width;
+    const scaleY = containerHeight / viewBox.height;
+
+    const targetZoom = 2.5;
+    setZoomLevel(targetZoom);
+    setPanOffset({
+      x: -(nucleotide.x - viewBoxCenterX) * scaleX * targetZoom,
+      y: -(nucleotide.y - viewBoxCenterY) * scaleY * targetZoom,
+    });
+  }, [focusNucleotideId]);
 
   const getFilteredOverlayValue = useCallback(
     (nucleotideId: number): { value: number; variant?: Variant } => {


### PR DESCRIPTION
## Description

Implements bidirectional navigation between the RNA secondary structure view and the genome browser linear view.

## Direction 1: RNA → Linear

Clicking a nucleotide in the RNA structure viewer now:
- Zooms the genome browser to center on that position (preserving zoom level)
- Highlights the matching variant dot with a dashed outline ellipse (via `isHighlighted` in `@gnomad/track-variants`)
- Works for all three tracks: ClinVar, gnomAD, and All of Us

## Direction 2: Linear → RNA

Clicking in the genome browser (via the `Cursor` component) now:
- Converts the genomic position to a nucleotide ID using `geneStart`/strand
- Finds the corresponding nucleotide in the RNA structure data
- Highlights it in the RNA viewer (same as clicking it directly)

## Changes

| File | Change |
|---|---|
| `MainContent.tsx` | Added `selectedVariantPos` state, `computeGenomicPos`/ `computeNucleotideId` helpers, `handleGenomeBrowserNavigate` callback; pass new props to `GenomeBrowser` |
| `GenomeBrowser.tsx` | Accept `selectedVariantPosition` + `onVariantNavigate` props; `useEffect` to zoom to selected position; call `onVariantNavigate` on cursor click |
| `SnRNAVariantTrack.tsx` | Accept `selectedVariantPosition` prop; set `isHighlighted` on matching variants across all three datasets