### PR TITLE
feat: add 404 catch-all route (#149)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Gene from "./pages/Gene";
 import Home from "./pages/Home";
 import HowToUse from "./pages/HowToUse";
 import Login from "./pages/Login";
+import NotFound from "./pages/NotFound";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 function ProtectedEditor() {
@@ -47,6 +48,7 @@ function App() {
             />
             <Route path="/how-to-use" element={<HowToUse />} />
             <Route path="/about" element={<About />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </Router>
       </TooltipProvider>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,32 @@
+import { FileQuestion, Home } from "lucide-react";
+import React from "react";
+import { Link } from "react-router-dom";
+import Footer from "../components/Footer";
+import Header from "../components/Header";
+import { Button } from "@/components/ui/button";
+
+const NotFound: React.FC = () => {
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 to-white">
+      <Header />
+      <main className="flex-1 flex items-center justify-center px-4">
+        <div className="text-center space-y-6 max-w-md">
+          <FileQuestion className="h-16 w-16 text-slate-300 mx-auto" />
+          <h1 className="text-4xl font-bold text-slate-800">404</h1>
+          <p className="text-lg text-slate-500">
+            The page you&rsquo;re looking for doesn&rsquo;t exist.
+          </p>
+          <Button asChild variant="outline" className="gap-2">
+            <Link to="/">
+              <Home className="h-4 w-4" />
+              Back to Home
+            </Link>
+          </Button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Description

Fixes #149 — invalid URLs now show a proper NotFound page with a link back home instead of a blank page.

## Changes

- **src/pages/NotFound.tsx** (new) — Simple 404 page with Header/Footer, 404 heading, descriptive message, and a "Back to Home" button
- **src/App.tsx** — Added import and catch-all route
