### PR TITLE
fix: overlay coloring and hover info for deletion/insertion spans (#218)

### DIFF
--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import React from "react";
 import { useNavigate } from "react-router";
+import { getAffectedNucleotideIds } from "../lib/rnaUtils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -55,7 +56,10 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
         variant.nucleotidePosition !== undefined &&
         variant.nucleotidePosition !== null
       ) {
-        return variant.nucleotidePosition === nucleotideId;
+        return getAffectedNucleotideIds(
+          variant.hgvs,
+          variant.nucleotidePosition,
+        ).includes(nucleotideId);
       } else if (variant.position) {
         let nucleotidePos: number;
         if (currentData.strand === "-") {
@@ -63,7 +67,9 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
         } else {
           nucleotidePos = variant.position - currentData.start + 1;
         }
-        return nucleotidePos === nucleotideId;
+        return getAffectedNucleotideIds(variant.hgvs, nucleotidePos).includes(
+          nucleotideId,
+        );
       }
       return false;
     });

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -16,7 +16,7 @@ import {
   COLORBLIND_FRIENDLY_PALETTE,
   generateGnomadColorWithAlpha,
 } from "../../lib/colors";
-import { findNucleotideById } from "../../lib/rnaUtils";
+import { findNucleotideById, getAffectedNucleotideIds } from "../../lib/rnaUtils";
 import type { RNAData, Nucleotide, OverlayData, Variant } from "../../types";
 import BasePairBond from "./BasePairBond";
 import NucleotideComponent from "./NucleotideComponent";
@@ -143,7 +143,12 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
             }
           }
 
-          if (nucleotidePos !== nucleotideId) return false;
+          if (
+            !getAffectedNucleotideIds(variant.hgvs, nucleotidePos).includes(
+              nucleotideId,
+            )
+          )
+            return false;
 
           if (!variant.clinical_significance) return false;
 
@@ -231,7 +236,12 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
             }
           }
 
-          if (nucleotidePos !== nucleotideId) return false;
+          if (
+            !getAffectedNucleotideIds(variant.hgvs, nucleotidePos).includes(
+              nucleotideId,
+            )
+          )
+            return false;
 
           const passesSource =
             selectedPopulationSource === "gnomad"
@@ -340,7 +350,10 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
           variant.nucleotidePosition !== undefined &&
           variant.nucleotidePosition !== null
         ) {
-          return variant.nucleotidePosition === nucleotideId;
+          return getAffectedNucleotideIds(
+            variant.hgvs,
+            variant.nucleotidePosition,
+          ).includes(nucleotideId);
         } else if (variant.position) {
           let nucleotidePos: number;
           if (geneData.strand === "-") {
@@ -348,7 +361,9 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
           } else {
             nucleotidePos = variant.position - geneData.start + 1;
           }
-          return nucleotidePos === nucleotideId;
+          return getAffectedNucleotideIds(variant.hgvs, nucleotidePos).includes(
+            nucleotideId,
+          );
         }
         return false;
       });

--- a/src/lib/rnaUtils.ts
+++ b/src/lib/rnaUtils.ts
@@ -16,3 +16,35 @@ export const findNucleotideById = (
 ): Nucleotide | undefined => {
   return nucleotides.find((n) => n.id === id);
 };
+
+export function getAffectedNucleotideIds(
+  hgvs: string | undefined,
+  nucleotidePosition: number,
+): number[] {
+  if (!hgvs) return [nucleotidePosition];
+
+  // Multi-position deletion: n.X_Ydel
+  const multiDel = hgvs.match(/^n\.(\d+)_(\d+)del/);
+  if (multiDel) {
+    const start = Number(multiDel[1]);
+    const end = Number(multiDel[2]);
+    const ids: number[] = [];
+    for (let i = start; i <= end; i++) ids.push(i);
+    return ids;
+  }
+
+  // Single-position deletion: n.Xdel
+  const singleDel = hgvs.match(/^n\.(\d+)del/);
+  if (singleDel) return [Number(singleDel[1])];
+
+  // Insertion: n.X_Yins — affects both flanking positions
+  const ins = hgvs.match(/^n\.(\d+)_(\d+)ins/);
+  if (ins) return [Number(ins[1]), Number(ins[2])];
+
+  // Duplication: n.Xdup
+  const dup = hgvs.match(/^n\.(\d+)dup/);
+  if (dup) return [Number(dup[1])];
+
+  // SNV or other — single position
+  return [nucleotidePosition];
+}


### PR DESCRIPTION
## Description

Fixes #218 — insertion variants now appear on both flanking nucleotides when hovering, and deletion/insertion variants are properly colored on all affected nucleotides in the RNA viewer overlay.

## Changes

- **src/lib/rnaUtils.ts** — Added `getAffectedNucleotideIds(hgvs, nucleotidePosition)` helper that returns all affected nucleotide IDs by parsing HGVS patterns: deletions (`n.Xdel`, `n.X_Ydel`), insertions (`n.X_Yins`), duplications (`n.Xdup`), and SNVs

- **src/components/RNAViewer/RNAViewer.tsx** — Updated `getFilteredOverlayValue` (both clinvar and gnomad modes) and `getVariantInfoForNucleotide` to use the helper

- **src/components/InfoPanel.tsx** — Updated `getVariantInfoForNucleotide` to use the helper