### PR TITLE
fix: hide Function Score track when no variant has function_score data

### DIFF
--- a/src/components/GenomeBrowser/FunctionScoreTrack.tsx
+++ b/src/components/GenomeBrowser/FunctionScoreTrack.tsx
@@ -64,6 +64,8 @@ const FunctionScoreTrack: React.FC<FunctionScoreTrackProps> = ({
       (p) => p.genomicPos >= currentRegion.start && p.genomicPos <= currentRegion.stop,
     );
 
+  if (points.length === 0) return null;
+
   const positions = [...new Set(points.map((p) => p.nucleotidePos))].sort(
     (a, b) => a - b,
   );


### PR DESCRIPTION
Fixes #246

When no variant in a gene has a `function_score` value, the Function Score track in the genome browser now returns `null` (hidden) instead of rendering an empty plot.

This follows the existing pattern used by `SequenceTrack` for conditional track visibility.