### PR TITLE
fix: exclude null depletion_group from overlay data to prevent false 'Normal' display

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -32,6 +32,7 @@ interface MainContentProps {
   overlayMode: "none" | "clinvar" | "gnomad" | "depletion_group";
   getCurrentOverlayData: () => OverlayData;
   cycleOverlayMode: () => void;
+  hasSgeData: boolean;
 }
 
 const MainContent: React.FC<MainContentProps> = ({
@@ -45,6 +46,7 @@ const MainContent: React.FC<MainContentProps> = ({
   overlayMode,
   getCurrentOverlayData,
   cycleOverlayMode,
+  hasSgeData,
 }) => {
   const [hoveredNucleotide, setHoveredNucleotide] = useState<Nucleotide | null>(null);
   const [selectedNucleotide, setSelectedNucleotide] = useState<Nucleotide | null>(null);
@@ -203,6 +205,7 @@ const MainContent: React.FC<MainContentProps> = ({
                   onCycleOverlay={cycleOverlayMode}
                   variantData={variantData}
                   gnomadVariants={gnomadVariants}
+                  hasSgeData={hasSgeData}
                   onNucleotideHover={setHoveredNucleotide}
                   onNucleotideClick={handleNucleotideClick}
                   selectedNucleotide={selectedNucleotide}

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -44,6 +44,7 @@ interface RNAViewerProps {
   onNucleotideHover?: (nucleotide: Nucleotide | null) => void;
   overlayMode?: "none" | "clinvar" | "gnomad" | "depletion_group";
   onCycleOverlay?: () => void;
+  hasSgeData?: boolean;
   variantData?: Variant[];
   gnomadVariants?: Variant[];
   selectedNucleotide?: Nucleotide | null;
@@ -72,6 +73,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
   onNucleotideHover,
   overlayMode = "clinvar",
   onCycleOverlay,
+  hasSgeData = true,
   variantData = [],
   gnomadVariants = [],
   selectedNucleotide = null,
@@ -593,30 +595,32 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                     <p>Show population frequency data from gnomAD and All of Us</p>
                   </TooltipContent>
                 </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={() => {
-                        const targetIndex = [
-                          "none",
-                          "clinvar",
-                          "gnomad",
-                          "depletion_group",
-                        ].indexOf("depletion_group");
-                        const current = cyclesFromMode(overlayMode);
-                        for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
-                          onCycleOverlay();
-                      }}
-                      className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "depletion_group" ? "bg-orange-100 text-orange-700" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
-                    >
-                      <Activity className="h-3.5 w-3.5" />
-                      <span className="hidden sm:inline">Depletion</span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Show depletion group categories: Strong, Moderate, Normal</p>
-                  </TooltipContent>
-                </Tooltip>
+                {hasSgeData && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => {
+                          const targetIndex = [
+                            "none",
+                            "clinvar",
+                            "gnomad",
+                            "depletion_group",
+                          ].indexOf("depletion_group");
+                          const current = cyclesFromMode(overlayMode);
+                          for (let i = 0; i < (targetIndex - current + 4) % 4; i++)
+                            onCycleOverlay?.();
+                        }}
+                        className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "depletion_group" ? "bg-orange-100 text-orange-700" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
+                      >
+                        <Activity className="h-3.5 w-3.5" />
+                        <span className="hidden sm:inline">Depletion</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Show depletion group categories: Strong, Moderate, Normal</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </div>
 
               {/* Structural Features Toggle */}

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -206,7 +206,7 @@ const Gene: React.FC = () => {
         case "clinvar":
           return "gnomad";
         case "gnomad":
-          return "depletion_group";
+          return hasSgeData ? "depletion_group" : "none";
         case "depletion_group":
           return "none";
         default:
@@ -244,6 +244,13 @@ const Gene: React.FC = () => {
 
   const gnomadVariants = getGnomadVariants();
   const aouVariants = getAllOfUsVariants();
+  const hasSgeData = variantData.some((v) => v.depletion_group != null);
+
+  useEffect(() => {
+    if (!hasSgeData && overlayMode === "depletion_group") {
+      setOverlayMode("clinvar");
+    }
+  }, [hasSgeData, overlayMode]);
 
   const handleGeneSelect = (geneName: string) => {
     navigate(`/gene/${geneName}`);
@@ -308,6 +315,7 @@ const Gene: React.FC = () => {
             overlayMode={overlayMode}
             getCurrentOverlayData={getCurrentOverlayData}
             cycleOverlayMode={cycleOverlayMode}
+            hasSgeData={hasSgeData}
             aouVariants={aouVariants}
           />
         </div>

--- a/src/pages/Gene.tsx
+++ b/src/pages/Gene.tsx
@@ -94,8 +94,7 @@ const Gene: React.FC = () => {
       return Object.fromEntries(
         variants
           .filter(
-            (v) =>
-              v.depletion_group !== undefined && v.nucleotidePosition !== undefined,
+            (v) => v.depletion_group != null && v.nucleotidePosition !== undefined,
           )
           .map((v) => [
             v.nucleotidePosition!,


### PR DESCRIPTION
Fixes #248

Two fixes for the Depletion Group overlay in the RNAViewer:

1. **Filter fix**: Clinical variants with `depletion_group: null` were passing through `createDepletionGroupTrackData` because `null !== undefined` is truthy in JS. Changed to `!= null` (loose check) to catch both `null` and `undefined`.

2. **UI fix**: When no variant has SGE data (`depletion_group`), the Depletion overlay tab button is now hidden entirely. The overlay cycle also skips the depletion mode when no SGE data exists, and the mode resets to `clinvar` if it was stuck on `depletion_group` after navigating away from a gene with SGE data.