### PR TITLE
fix: remove p-value/q-value from InfoPanel, rename Depletion to Depletion Group

### DIFF
--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -357,11 +357,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
                               (variant.ukbb_ac !== undefined && variant.ukbb_ac > 0) ||
                               (variant.function_score !== undefined &&
                                 variant.function_score !== null) ||
-                              variant.depletion_group != null ||
-                              (variant.pvalues !== undefined &&
-                                variant.pvalues !== null) ||
-                              (variant.qvalues !== undefined &&
-                                variant.qvalues !== null);
+                              variant.depletion_group != null;
 
                             return (
                               <div
@@ -434,26 +430,10 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
                                         </span>
                                       )}
                                     {variant.depletion_group != null && (
-                                      <span>Depletion: {variant.depletion_group}</span>
+                                      <span>
+                                        Depletion Group: {variant.depletion_group}
+                                      </span>
                                     )}
-                                    {variant.pvalues !== undefined &&
-                                      variant.pvalues !== null && (
-                                        <span>
-                                          P:{" "}
-                                          {variant.pvalues < 0.001
-                                            ? "<0.001"
-                                            : variant.pvalues.toFixed(3)}
-                                        </span>
-                                      )}
-                                    {variant.qvalues !== undefined &&
-                                      variant.qvalues !== null && (
-                                        <span>
-                                          Q:{" "}
-                                          {variant.qvalues < 0.001
-                                            ? "<0.001"
-                                            : variant.qvalues.toFixed(3)}
-                                        </span>
-                                      )}
                                   </div>
                                 )}
 
@@ -553,7 +533,9 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
                                         </span>
                                       )}
                                     {variant.depletion_group && (
-                                      <span>Depletion: {variant.depletion_group}</span>
+                                      <span>
+                                        Depletion Group: {variant.depletion_group}
+                                      </span>
                                     )}
                                   </div>
                                 </div>

--- a/src/components/RNAViewer/RNAViewer.tsx
+++ b/src/components/RNAViewer/RNAViewer.tsx
@@ -613,7 +613,7 @@ const RNAViewer: React.FC<RNAViewerProps> = ({
                         className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors flex items-center gap-1.5 ${overlayMode === "depletion_group" ? "bg-orange-100 text-orange-700" : "bg-slate-100 text-slate-500 hover:bg-slate-200"}`}
                       >
                         <Activity className="h-3.5 w-3.5" />
-                        <span className="hidden sm:inline">Depletion</span>
+                        <span className="hidden sm:inline">Depletion Group</span>
                       </button>
                     </TooltipTrigger>
                     <TooltipContent>


### PR DESCRIPTION
Fixes #254. Partially addresses #211.

### Changes

**InfoPanel.tsx:**
- Removed p-value and q-value display from clinical variant metadata rows
- Removed pvalues/qvalues from `hasMeta` visibility check
- Renamed `Depletion:` → `Depletion Group:` in both clinical and population variant sections

**RNAViewer.tsx:**
- Renamed overlay mode button label from `Depletion` to `Depletion Group`

### Not changed
- Data model (`pvalues`, `qvalues`, `depletion_group` fields remain in types/API/DB)
- Curation tools (`VariantForm`, `VariantImportWizard`)
- `VariantLiteratureCard`

### Deferred
ACMG evidence field (from #211) will be addressed in a follow-up issue.